### PR TITLE
.travis.yml: Fix build for `polyval` crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 
 script:
-  - cargo test --all --release
+  - cargo test --all --exclude polyval --release
   - cargo test --all --all-features --release
 
 env:
@@ -22,12 +22,22 @@ matrix:
     - name: "Rust: 1.36.0"
       rust: 1.36.0
       env: {} # clear `-D warnings` above; allow warnings
+
+    # polyval presently needs either RUSTFLAGS or non-default features
+    - name: "Rust: 1.32.0 (polyval)"
+      rust: 1.32.0
+      script: ./test_polyval.sh
+    - name: "Rust: stable (polyval)"
+      rust: stable
+      script: ./test_polyval.sh
+
+    # no_std build
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable
       install:
         - rustup target add thumbv7em-none-eabihf
       script:
-        - cargo build --all --target thumbv7em-none-eabihf --release
+        - cargo build --all --exclude polyval --target thumbv7em-none-eabihf --release
     - name: rustfmt
       rust: stable
       install:

--- a/test_polyval.sh
+++ b/test_polyval.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eux
+
+# Test with the `insecure-soft` backend enabled
+cargo test --package=polyval --all-features
+
+# Test without `insecure-soft` but with PCLMULQDQ hardware intrinsics
+RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+sse2,+sse4.1" cargo test --package polyval --tests
+
+# Test with both `insecure-soft` and PCLMULQDQ hardware intrinsics (uses PCLMULQDQ)
+RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+sse2,+sse4.1" cargo test --package polyval --all-features


### PR DESCRIPTION
The `polyval` crate presently needs either special `RUSTFLAGS` or non-default features.

I do intend to fix that (I have a half-finished pure software constant-time implementation which performs ~3X better than the current completely naive non-constant-time version) but for now I just want to get CI green.