### PR TITLE
Fix links after move from RustCrypto/MACs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RustCrypto: Universal Hash Functions
-[![Build Status](https://travis-ci.org/RustCrypto/universal-hashes.svg?branch=master)](https://travis-ci.org/RustCrypto/universal-hashes) [![dependency status](https://deps.rs/repo/github/RustCrypto/universal-hashes/status.svg)](https://deps.rs/repo/github/universal-hashes/stream-ciphers)
+[![Build Status](https://travis-ci.com/RustCrypto/universal-hashes.svg?branch=master)](https://travis-ci.com/RustCrypto/universal-hashes) [![dependency status](https://deps.rs/repo/github/RustCrypto/universal-hashes/status.svg)](https://deps.rs/repo/github/universal-hashes/stream-ciphers)
 
 Collection of [Universal Hash Functions][1] written in pure Rust.
 

--- a/poly1305/CHANGES.md
+++ b/poly1305/CHANGES.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.0 (2019-08-26)
 ### Changed
-- Switch from `MacResult` to built-in `Tag` type ([#13])
+- Switch from `MacResult` to built-in `Tag` type ([RustCrypto/MACs#13])
 
-[#13]: https://github.com/RustCrypto/MACs/pull/13
+[RustCrypto/MACs#13]: https://github.com/RustCrypto/MACs/pull/13
 
 ## 0.2.0 (2019-08-19)
 ### Added
 - `Poly1305::input_padded()` ([#16])
 
 ### Changed
-- Change output to be a `MacResult` ([#16])
+- Change output to be a `MacResult` ([RustCrypto/MACs#16])
 
-[#16]: https://github.com/RustCrypto/MACs/pull/16
+[RustCrypto/MACs#16]: https://github.com/RustCrypto/MACs/pull/16
 
 ## 0.1.0 (2019-08-15)
 

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "The Poly1305 universal hash function and message authentication code"
 documentation = "https://docs.rs/poly1305"
-repository = "https://github.com/RustCrypto/MACs"
+repository = "https://github.com/RustCrypto/universal-hashes"
 keywords = ["crypto", "mac", "umac", "universal-hashing"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
@@ -20,4 +20,4 @@ crypto-mac = { version = "0.7", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "RustCrypto/hashes" }
+travis-ci = { repository = "RustCrypto/universal-hashes" }

--- a/poly1305/README.md
+++ b/poly1305/README.md
@@ -47,8 +47,8 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
-[build-image]: https://travis-ci.org/RustCrypto/MACs.svg?branch=master
-[build-link]: https://travis-ci.org/RustCrypto/MACs
+[build-image]: https://travis-ci.com/RustCrypto/universal-hashes.svg?branch=master
+[build-link]: https://travis-ci.com/RustCrypto/universal-hashes
 
 [//]: # (general links)
 

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -8,7 +8,7 @@ POLYVAL is a GHASH-like universal hash over GF(2^128) useful for constructing
 a Message Authentication Code (MAC)
 """
 documentation = "https://docs.rs/polyval"
-repository = "https://github.com/RustCrypto/MACs"
+repository = "https://github.com/RustCrypto/universal-hashes"
 readme = "README.md"
 keywords = ["aes-gcm-siv", "crypto", "universal-hashing"]
 categories = ["cryptography", "no-std"]
@@ -26,7 +26,7 @@ insecure-soft = []
 
 [badges]
 maintenance = { status = "experimental" }
-travis-ci = { repository = "RustCrypto/hashes" }
+travis-ci = { repository = "RustCrypto/universal-hashes" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polyval/README.md
+++ b/polyval/README.md
@@ -49,8 +49,8 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
-[build-image]: https://travis-ci.org/RustCrypto/MACs.svg?branch=master
-[build-link]: https://travis-ci.org/RustCrypto/MACs
+[build-image]: https://travis-ci.com/RustCrypto/universal-hashes.svg?branch=master
+[build-link]: https://travis-ci.com/RustCrypto/universal-hashes
 
 [//]: # (general links)
 


### PR DESCRIPTION
Several links in the README.md and `Cargo.toml` files need to be updated to reflect the new repository.