### PR TITLE
ghash: Split from `polyval` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "ghash",
     "poly1305",
     "polyval"
 ]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ security reviews.
 ## Crates
 | Name | Crates.io | Documentation |
 | ---- | :--------:| :------------:|
+| `ghash` | [![crates.io](https://img.shields.io/crates/v/ghash.svg)](https://crates.io/crates/ghash) | [![Documentation](https://docs.rs/ghash/badge.svg)](https://docs.rs/ghash) |
 | `poly1305` | [![crates.io](https://img.shields.io/crates/v/poly1305.svg)](https://crates.io/crates/poly1305) | [![Documentation](https://docs.rs/poly1305/badge.svg)](https://docs.rs/poly1305) |
-| `polyval`  | [![crates.io](https://img.shields.io/crates/v/polyval.svg)](https://crates.io/crates/poly1305)  | [![Documentation](https://docs.rs/polyval/badge.svg)](https://docs.rs/polyval) |
+| `polyval`  | [![crates.io](https://img.shields.io/crates/v/polyval.svg)](https://crates.io/crates/polyval) | [![Documentation](https://docs.rs/polyval/badge.svg)](https://docs.rs/polyval) |
 
 ### Minimum Supported Rust Version
 All crates in this repository support Rust 1.34 or higher. In future minimum

--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,28 +1,27 @@
 [package]
-name = "polyval"
-version = "0.0.1"
+name = "ghash"
+version = "0.0.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """
-POLYVAL is a GHASH-like universal hash over GF(2^128) useful for constructing
-a Message Authentication Code (MAC)
+Universal hash over GF(2^128) useful for constructing a Message Authentication Code (MAC),
+as in the AES-GCM authenticated encryption cipher.
 """
-documentation = "https://docs.rs/polyval"
+documentation = "https://docs.rs/ghash"
 repository = "https://github.com/RustCrypto/universal-hashes"
 readme = "README.md"
-keywords = ["aes-gcm-siv", "crypto", "universal-hashing"]
+keywords = ["aes-gcm", "crypto", "universal-hashing"]
 categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-universal-hash = { version = "0.2", default-features = false }
-zeroize = { version = "0.10", optional = true, default-features = false }
+polyval = { version = "0.0.1", path = "../polyval" }
 
 [dev-dependencies]
 hex-literal = "0.1"
 
 [features]
-std = ["universal-hash/std"]
+std = ["polyval/std"]
 
 [badges]
 maintenance = { status = "experimental" }

--- a/ghash/LICENSE-APACHE
+++ b/ghash/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ghash/LICENSE-MIT
+++ b/ghash/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ghash/README.md
+++ b/ghash/README.md
@@ -1,0 +1,57 @@
+# GHASH: fast universal hash function and MAC
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+![Maintenance Status: Experimental][maintenance-image]
+[![Build Status][build-image]][build-link]
+
+[GHASH][1] is a [universal hash function][2] which operates over GF(2^128) and
+can be used for constructing a [Message Authentication Code (MAC)][3].
+
+Its primary intended use is for implementing [AES-GCM][4].
+
+[Documentation][docs-link]
+
+## Security Warning
+
+No security audits of this crate have ever been performed, and it has not been
+thoroughly assessed to ensure its operation is constant-time on common CPU
+architectures.
+
+USE AT YOUR OWN RISK!
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/ghash.svg
+[crate-link]: https://crates.io/crates/ghash
+[docs-image]: https://docs.rs/ghash/badge.svg
+[docs-link]: https://docs.rs/ghash/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+[build-image]: https://travis-ci.com/RustCrypto/universal-hashes.svg?branch=master
+[build-link]: https://travis-ci.com/RustCrypto/universal-hashes
+
+[//]: # (general links)
+
+[1]: https://en.wikipedia.org/wiki/Galois/Counter_Mode#Mathematical_basis
+[2]: https://en.wikipedia.org/wiki/Universal_hashing
+[3]: https://en.wikipedia.org/wiki/Message_authentication_code
+[4]: https://en.wikipedia.org/wiki/Galois/Counter_Mode

--- a/ghash/benches/ghash.rs
+++ b/ghash/benches/ghash.rs
@@ -1,0 +1,29 @@
+#![feature(test)]
+
+extern crate test;
+
+use ghash::{universal_hash::UniversalHash, GHash};
+use test::Bencher;
+
+// TODO(tarcieri): move this into the `universal-hash` crate
+macro_rules! bench {
+    ($name:ident, $bs:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let key = Default::default();
+            let mut m = GHash::new(&key);
+            let data = [0; $bs];
+
+            b.iter(|| {
+                m.update_padded(&data);
+            });
+
+            b.bytes = $bs;
+        }
+    };
+}
+
+bench!(bench1_10, 10);
+bench!(bench2_100, 100);
+bench!(bench3_1000, 1000);
+bench!(bench3_10000, 10000);

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -1,9 +1,13 @@
 //! **GHASH**: universal hash over GF(2^128) used by AES-GCM.
 
-use crate::{
-    field::{backend::U64x2, Block},
-    Polyval,
-};
+#![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use polyval::universal_hash;
+
+use core::convert::TryInto;
+use polyval::{field::Block, Polyval};
 use universal_hash::generic_array::{typenum::U16, GenericArray};
 use universal_hash::{Output, UniversalHash};
 
@@ -20,7 +24,6 @@ use universal_hash::{Output, UniversalHash};
 /// > irreducible polynomials: POLYVAL works modulo x^128 + x^127 + x^126 +
 /// > x^121 + 1 and GHASH works modulo x^128 + x^7 + x^2 + x + 1.  Note
 /// > that these irreducible polynomials are the "reverse" of each other.
-#[allow(non_snake_case)]
 #[derive(Clone)]
 #[repr(align(16))]
 pub struct GHash(Polyval);
@@ -33,9 +36,7 @@ impl UniversalHash for GHash {
     fn new(h: &GenericArray<u8, U16>) -> Self {
         let mut h: Block = h.clone().into();
         h.reverse();
-
-        let h_polyval: Block = U64x2::from(h).mulx().into();
-        GHash(Polyval::new(&h_polyval.into()))
+        GHash(Polyval::new(&mulX_POLYVAL(h).into()))
     }
 
     /// Input a field element `X` to be authenticated
@@ -56,4 +57,25 @@ impl UniversalHash for GHash {
         output.reverse();
         Output::new(output.into())
     }
+}
+
+/// The `mulX_POLYVAL()` function as defined in [RFC 8452 Appendix A][1].
+/// Performs a doubling (a.k.a. "multiply by x") over GF(2^128).
+/// This is useful for implementing GHASH in terms of POLYVAL.
+///
+/// [1]: https://tools.ietf.org/html/rfc8452#appendix-A
+#[allow(non_snake_case)]
+fn mulX_POLYVAL(block: Block) -> Block {
+    let mut v0 = u64::from_le_bytes(block[..8].try_into().unwrap());
+    let mut v1 = u64::from_le_bytes(block[8..].try_into().unwrap());
+
+    let v0h = v0 >> 63;
+    let v1h = v1 >> 63;
+
+    v0 <<= 1;
+    v1 <<= 1;
+    v0 ^= v1h;
+    v1 ^= v0h ^ (v1h << 63) ^ (v1h << 62) ^ (v1h << 57);
+
+    (u128::from(v0) | (u128::from(v1) << 64)).to_le_bytes()
 }

--- a/ghash/tests/lib.rs
+++ b/ghash/tests/lib.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate hex_literal;
+
+use ghash::{universal_hash::UniversalHash, GHash};
+
+//
+// Test vectors for GHASH from RFC 8452 Appendix A
+// <https://tools.ietf.org/html/rfc8452#appendix-A>
+//
+
+const H: [u8; 16] = hex!("25629347589242761d31f826ba4b757b");
+const X_1: [u8; 16] = hex!("4f4f95668c83dfb6401762bb2d01a262");
+const X_2: [u8; 16] = hex!("d1a24ddd2721d006bbe45f20d3c9f362");
+
+/// GHASH(H, X_1, X_2)
+const GHASH_RESULT: [u8; 16] = hex!("bd9b3997046731fb96251b91f9c99d7a");
+
+#[test]
+fn ghash_test_vector() {
+    let mut ghash = GHash::new(&H.into());
+    ghash.update_block(&X_1.into());
+    ghash.update_block(&X_2.into());
+
+    let result = ghash.result();
+    assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
+}

--- a/polyval/src/field/backend/soft.rs
+++ b/polyval/src/field/backend/soft.rs
@@ -113,27 +113,6 @@ impl Mul for U64x2 {
     }
 }
 
-impl U64x2 {
-    /// The `mulX_POLYVAL()` function as defined in [RFC 8452 Appendix A][1].
-    /// Performs a doubling (a.k.a. "multiply by x") over GF(2^128).
-    /// This is useful for implementing GHASH in terms of POLYVAL.
-    ///
-    /// [1]: https://tools.ietf.org/html/rfc8452#appendix-A
-    pub fn mulx(self) -> Self {
-        let mut v0 = self.0;
-        let mut v1 = self.1;
-        let v0h = v0 >> 63;
-        let v1h = v1 >> 63;
-
-        v0 <<= 1;
-        v1 <<= 1;
-        v0 ^= v1h;
-        v1 ^= v0h ^ (v1h << 63) ^ (v1h << 62) ^ (v1h << 57);
-
-        U64x2(v0, v1)
-    }
-}
-
 /// Reverse a `u64` in constant time
 fn rev64(mut x: u64) -> u64 {
     x = ((x & 0x5555_5555_5555_5555) << 1) | ((x >> 1) & 0x5555_5555_5555_5555);

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -23,9 +23,6 @@
 //!
 //! ## Relationship to GHASH
 //!
-//! This crate also provides an implementation of **GHASH** gated under the
-//! `ghash` cargo feature and the [`GHash`] type.
-//!
 //! POLYVAL can be thought of as the little endian equivalent of GHASH, which
 //! affords it a small performance advantage over GHASH when used on little
 //! endian architectures.
@@ -50,11 +47,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 pub mod field;
-#[cfg(feature = "ghash")]
-mod ghash;
 
-#[cfg(feature = "ghash")]
-pub use self::ghash::GHash;
 pub use universal_hash;
 
 use universal_hash::generic_array::{typenum::U16, GenericArray};

--- a/polyval/tests/lib.rs
+++ b/polyval/tests/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate hex_literal;
 
-#[cfg(feature = "ghash")]
-use polyval::GHash;
 use polyval::{universal_hash::UniversalHash, Polyval};
 
 //
@@ -17,10 +15,6 @@ const X_2: [u8; 16] = hex!("d1a24ddd2721d006bbe45f20d3c9f362");
 /// POLYVAL(H, X_1, X_2)
 const POLYVAL_RESULT: [u8; 16] = hex!("f7a3b47b846119fae5b7866cf5e5b77e");
 
-/// GHASH(H, X_1, X_2)
-#[cfg(feature = "ghash")]
-const GHASH_RESULT: [u8; 16] = hex!("bd9b3997046731fb96251b91f9c99d7a");
-
 #[test]
 fn polyval_test_vector() {
     let mut poly = Polyval::new(&H.into());
@@ -29,15 +23,4 @@ fn polyval_test_vector() {
 
     let result = poly.result();
     assert_eq!(&POLYVAL_RESULT[..], result.into_bytes().as_slice());
-}
-
-#[cfg(feature = "ghash")]
-#[test]
-fn ghash_test_vector() {
-    let mut ghash = GHash::new(&H.into());
-    ghash.update_block(&X_1.into());
-    ghash.update_block(&X_2.into());
-
-    let result = ghash.result();
-    assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
 }


### PR DESCRIPTION
This extracts `ghash` into its own crate.

In attempting to add runtime detection to `polyval`, having `ghash` in the same crate felt in-the-way. In this commit, I have split the two crates in advance, and then I'll rebase my runtime detection into its own commit.

I think we only need two crates here, as the `ghash` crate is implemented in terms of POLYVAL's field/polynomial:

`GHASH(H, X_1, ..., X_n)` =>
`ByteReverse(POLYVAL(mulX_POLYVAL(ByteReverse(H)), ByteReverse(X_1), ..., ByteReverse(X_n)))`

Though they both operate over GF(2^128), there are some slight discrepancies in the field arithmetic owing to the polynomial, and this approach leverages the fact that the POLYVAL polynomial is the "reverse" of the GHASH one.