### PR TITLE
polyval: Simplify implementation

### DIFF
--- a/polyval/src/field/backend.rs
+++ b/polyval/src/field/backend.rs
@@ -1,37 +1,6 @@
 //! Field arithmetic backends
 
-#[cfg(all(
-    target_feature = "pclmulqdq",
-    target_feature = "sse2",
-    target_feature = "sse4.1",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
-mod pclmulqdq;
-mod soft;
 
-use super::Block;
-use core::ops::{Add, Mul};
-
-// TODO(tarcieri): runtime selection of PCLMULQDQ based on CPU features
-
-#[cfg(all(
-    target_feature = "pclmulqdq",
-    target_feature = "sse2",
-    target_feature = "sse4.1",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
-pub(crate) use self::pclmulqdq::M128i;
-
-#[allow(unused_imports)]
-pub(crate) use self::soft::U64x2;
-
-#[cfg(not(all(
-    target_feature = "pclmulqdq",
-    target_feature = "sse2",
-    target_feature = "sse4.1",
-    any(target_arch = "x86", target_arch = "x86_64")
-)))]
-pub(crate) type M128i = U64x2;
 
 /// Field arithmetic backend
 pub trait Backend:

--- a/polyval/src/field/pclmulqdq.rs
+++ b/polyval/src/field/pclmulqdq.rs
@@ -6,7 +6,6 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-use super::Backend;
 use crate::field::Block;
 use core::ops::{Add, Mul};
 
@@ -14,8 +13,6 @@ use core::ops::{Add, Mul};
 #[repr(align(16))]
 #[derive(Copy, Clone)]
 pub struct M128i(__m128i);
-
-impl Backend for M128i {}
 
 impl From<Block> for M128i {
     // `_mm_loadu_si128` performs an unaligned load

--- a/polyval/src/field/soft.rs
+++ b/polyval/src/field/soft.rs
@@ -5,7 +5,6 @@
 //!
 //! Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
 
-use super::Backend;
 use crate::field::Block;
 use core::{
     convert::TryInto,
@@ -15,8 +14,6 @@ use core::{
 /// 2 x `u64` values
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct U64x2(u64, u64);
-
-impl Backend for U64x2 {}
 
 impl From<Block> for U64x2 {
     fn from(bytes: Block) -> U64x2 {

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -53,19 +53,16 @@ pub use universal_hash;
 use universal_hash::generic_array::{typenum::U16, GenericArray};
 use universal_hash::{Output, UniversalHash};
 
-// TODO(tarcieri): runtime selection of CLMUL vs soft backend when both are available
-use field::backend::M128i;
-
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[allow(non_snake_case)]
 #[derive(Clone)]
 #[repr(align(16))]
 pub struct Polyval {
     /// GF(2^128) field element input blocks are multiplied by
-    H: field::Element<M128i>,
+    H: field::Element,
 
     /// Field element representing the computed universal hash
-    S: field::Element<M128i>,
+    S: field::Element,
 }
 
 impl UniversalHash for Polyval {


### PR DESCRIPTION
Eliminate needless traits and module depth, making `field::Element` into a simple newtype wrapper.