### PR TITLE
polyval v0.1.0

### DIFF
--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -2,5 +2,5 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-polyval = { version = "0.0.1", path = "../polyval" }
+polyval = { version = "0.1", path = "../polyval" }
 
 [dev-dependencies]
 hex-literal = "0.1"

--- a/polyval/CHANGES.md
+++ b/polyval/CHANGES.md
@@ -2,8 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (2019-09-19)
+
+### Added
+- Constant time software implementation ([#7])
+
+### Changed
+- Update to Rust 2018 edition ([#3])
+- Use `UniversalHash` trait ([#6])
+- Removed generics/traits from `field::Element` API ([#12])
+
+### Removed
+- `insecure-soft` cargo feature ([#7])
+
+[#3]: https://github.com/RustCrypto/universal-hashes/pull/3
+[#6]: https://github.com/RustCrypto/universal-hashes/pull/6
+[#7]: https://github.com/RustCrypto/universal-hashes/pull/7
+[#12]: https://github.com/RustCrypto/universal-hashes/pull/12
 
 ## 0.0.1 (2019-08-26)
 

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """

--- a/polyval/src/field.rs
+++ b/polyval/src/field.rs
@@ -52,6 +52,7 @@ pub type Block = [u8; FIELD_SIZE];
 
 /// POLYVAL field element.
 #[derive(Copy, Clone)]
+#[repr(transparent)]
 pub struct Element(M128i);
 
 impl Element {


### PR DESCRIPTION
### Added
- Constant time software implementation ([#7])

### Changed
- Update to Rust 2018 edition ([#3])
- Use `UniversalHash` trait ([#6])
- Removed generics/traits from `field::Element` API ([#12])

### Removed
- `insecure-soft` cargo feature ([#7])

[#3]: https://github.com/RustCrypto/universal-hashes/pull/3
[#6]: https://github.com/RustCrypto/universal-hashes/pull/6
[#7]: https://github.com/RustCrypto/universal-hashes/pull/7
[#12]: https://github.com/RustCrypto/universal-hashes/pull/12