### PR TITLE
polyval v0.1.1

### DIFF
--- a/polyval/CHANGES.md
+++ b/polyval/CHANGES.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2019-10-01)
+
+## Changed
+- Upgrade to `zeroize` v1.0.0-pre ([#19])
+
+[#19]: https://github.com/RustCrypto/universal-hashes/pull/19
+
 ## 0.1.0 (2019-09-19)
 
 ### Added

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
- Upgrade to `zeroize` v1.0.0-pre ([#19])

[#19]: https://github.com/RustCrypto/universal-hashes/pull/19