### PR TITLE
poly1305 v0.5.0

### DIFF
--- a/poly1305/CHANGES.md
+++ b/poly1305/CHANGES.md
@@ -5,15 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.1 (2019-10-01)
+## 0.5.0 (2019-10-04)
+### Changed
+- Upgrade to `universal-hash` crate v0.3 ([#22])
 
-## Changed
+[#22]: https://github.com/RustCrypto/universal-hashes/pull/22
+
+## 0.4.1 (2019-10-01)
+### Changed
 - Upgrade to `zeroize` v1.0.0-pre ([#19])
 
 [#19]: https://github.com/RustCrypto/universal-hashes/pull/19
 
 ## 0.4.0 (2019-09-29)
-
 ### Changed
 - Update to Rust 2018 edition ([#3])
 - Use `UniversalHash` trait ([#5])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Changed
- Upgrade to `universal-hash` crate v0.3 ([#22])

[#22]: https://github.com/RustCrypto/universal-hashes/pull/22