### PR TITLE
polyval v0.2.0

### DIFF
--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-polyval = { version = "0.1", path = "../polyval" }
+polyval = { version = "0.2", path = "../polyval" }
 
 [dev-dependencies]
 hex-literal = "0.1"

--- a/polyval/CHANGES.md
+++ b/polyval/CHANGES.md
@@ -5,15 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1 (2019-10-01)
+## 0.2.0 (2019-10-04)
+### Changed
+- Upgrade to `universal-hash` crate v0.3 ([#22])
 
-## Changed
+[#22]: https://github.com/RustCrypto/universal-hashes/pull/22
+
+## 0.1.1 (2019-10-01)
+### Changed
 - Upgrade to `zeroize` v1.0.0-pre ([#19])
 
 [#19]: https://github.com/RustCrypto/universal-hashes/pull/19
 
 ## 0.1.0 (2019-09-19)
-
 ### Added
 - Constant time software implementation ([#7])
 

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
### Changed
- Upgrade to `universal-hash` crate v0.3 ([#22])

[#22]: https://github.com/RustCrypto/universal-hashes/pull/22