### PR TITLE
poly1305 v0.5.1

### DIFF
--- a/poly1305/CHANGES.md
+++ b/poly1305/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2019-10-04)
+### Added
+- Link to `chacha20poly1305` and `xsalsa20poly1305` crates from README.md ([#26])
+
+[#26]: https://github.com/RustCrypto/universal-hashes/pull/26
+
 ## 0.5.0 (2019-10-04)
 ### Changed
 - Upgrade to `universal-hash` crate v0.3 ([#22])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Added
- Link to `chacha20poly1305` and `xsalsa20poly1305` crates from README.md ([#26])

[#26]: https://github.com/RustCrypto/universal-hashes/pull/26