### PR TITLE
polyval: Remove `pub` from `field` module

### DIFF
--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 
 [dependencies]
 polyval = { version = "0.2", path = "../polyval" }
+zeroize = { version = "1.0.0-pre", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.1"

--- a/polyval/benches/polyval.rs
+++ b/polyval/benches/polyval.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use polyval::{universal_hash::UniversalHash, Polyval};
-use test::{Bencher, black_box};
+use test::{black_box, Bencher};
 
 // TODO(tarcieri): move this into the `universal-hash` crate
 macro_rules! bench {

--- a/polyval/src/field.rs
+++ b/polyval/src/field.rs
@@ -44,11 +44,8 @@ use self::soft::U64x2;
 )))]
 type M128i = U64x2;
 
-/// Size of GF(2^128) in bytes (16-bytes).
-pub const FIELD_SIZE: usize = 16;
-
 /// POLYVAL field element bytestrings (16-bytes)
-pub type Block = [u8; FIELD_SIZE];
+type Block = [u8; 16];
 
 /// POLYVAL field element.
 #[derive(Copy, Clone)]

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -46,7 +46,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub mod field;
+mod field;
 
 pub use universal_hash;
 


### PR DESCRIPTION
We don't actually need to expose this, even for `ghash`.

Keeping it out of the public API until we actually have a legitimate use case for exposing it will increase flexibility when we do want to.