### PR TITLE
ghash v0.2.1

### DIFF
--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2019-10-05)
+### Changed
+- Upgrade to `polyval` v0.3 ([#29])
+
+[#29]: https://github.com/RustCrypto/universal-hashes/pull/29
+
 ## 0.2.0 (2019-10-04)
 ### Changed
 - Upgrade to `polyval` v0.2 and `universal-hash` crate v0.3 ([#22])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
### Changed
- Upgrade to `polyval` v0.3 ([#29])

[#29]: https://github.com/RustCrypto/universal-hashes/pull/29