### PR TITLE
ghash v0.2.2

### DIFF
--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2019-10-06)
+### Fixed
+- Revert mulX_POLYVAL changes from [#28] ([#31])
+
+[#31]: https://github.com/RustCrypto/universal-hashes/pull/31
+
 ## 0.2.1 (2019-10-05)
 ### Changed
-- Upgrade to `polyval` v0.3 ([#29])
+- Upgrade to `polyval` v0.3 ([#28], [#29])
 
 [#29]: https://github.com/RustCrypto/universal-hashes/pull/29
+[#28]: https://github.com/RustCrypto/universal-hashes/pull/28
 
 ## 0.2.0 (2019-10-04)
 ### Changed

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
## 0.2.2 (2019-10-06)
### Fixed
- Revert mulX_POLYVAL changes from #28 ([#31])

[#31]: https://github.com/RustCrypto/universal-hashes/pull/31