### PR TITLE
Upgrade to `zeroize` 1.0

### DIFF
--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 polyval = { version = "0.3", path = "../polyval" }
-zeroize = { version = "1.0.0-pre", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.1"

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 universal-hash = { version = "0.3", default-features = false }
-zeroize = { version = "1.0.0-pre", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [features]
 std = ["universal-hash/std"]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 universal-hash = { version = "0.3", default-features = false }
-zeroize = { version = "1.0.0-pre", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.1"


### PR DESCRIPTION
This removes the `-pre` from the requirements for all crates which are using it.

Due to semver all of these crates are already using `zeroize` 1.0. This commit just clarifies which versions are used by updating the requirement to suit.