### PR TITLE
ghash v0.2.3

### DIFF
--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2019-11-14)
+### Changed
+- Upgrade to `zeroize` 1.0 ([#33])
+
+[#33]: https://github.com/RustCrypto/universal-hashes/pull/33
+
 ## 0.2.2 (2019-10-06)
 ### Fixed
 - Revert mulX_POLYVAL changes from [#28] ([#31])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
### Changed
- Upgrade to `zeroize` 1.0 ([#33])

[#33]: https://github.com/RustCrypto/universal-hashes/pull/33