### PR TITLE
Use correct `pshufd` intrinsic

### DIFF
--- a/polyval/src/field.rs
+++ b/polyval/src/field.rs
@@ -18,6 +18,7 @@ mod pclmulqdq;
 mod u32_soft;
 mod u64_soft;
 
+#[allow(unused_imports)]
 use cfg_if::cfg_if;
 use core::ops::{Add, Mul};
 

--- a/polyval/src/field/pclmulqdq.rs
+++ b/polyval/src/field/pclmulqdq.rs
@@ -81,9 +81,9 @@ unsafe fn reduce(x: __m128i) -> __m128i {
     #[allow(clippy::cast_ptr_alignment)]
     let mask = _mm_loadu_si128(&MASK as *const u128 as *const __m128i);
     let a = pclmulqdq(mask, x, 0x01);
-    let b = xor(shufpd1(x), a);
+    let b = xor(pshufd(x), a);
     let c = pclmulqdq(mask, b, 0x01);
-    xor(shufpd1(b), c)
+    xor(pshufd(b), c)
 }
 
 #[target_feature(enable = "sse2", enable = "sse4.1")]
@@ -92,9 +92,8 @@ unsafe fn xor(a: __m128i, b: __m128i) -> __m128i {
 }
 
 #[target_feature(enable = "sse2", enable = "sse4.1")]
-unsafe fn shufpd1(a: __m128i) -> __m128i {
-    let a = _mm_castsi128_pd(a);
-    _mm_castpd_si128(_mm_shuffle_pd(a, a, 1))
+unsafe fn pshufd(a: __m128i) -> __m128i {
+    _mm_shuffle_epi32(a, 0x4e)
 }
 
 #[target_feature(enable = "sse2", enable = "sse4.1")]


### PR DESCRIPTION
Previously the implementation used the `_mm_shuffle_pd` intrinsic which maps to the `shufpd` (floating point shuffle) instruction.

This still produced the correct assembly (i.e. `pshufd`), as LLVM noticed the inputs and outputs were integers and substituted `pshufd` for `shufpd`, which is the correct ASM according to this QuarksLab blog post:

https://blog.quarkslab.com/reversing-a-finite-field-multiplication-optimization.html

This changes the code to call the proper `pshufd` intrinsic directly (`_mm_shuffle_epi32`), which is cleaner.