### PR TITLE
polyval v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ name = "ghash"
 version = "0.3.0-pre"
 dependencies = [
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "polyval 0.4.0-pre",
+ "polyval 0.4.0",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-polyval = { version = "= 0.4.0-pre", path = "../polyval" }
+polyval = { version = "0.4", path = "../polyval" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-06-06)
+### Changed
+- Bump `universal-hash` dependency to v0.4; MSRV 1.41 ([#52], [#57])
+- Rename `result` methods to to `finalize` ([#56])
+
+[#57]: https://github.com/RustCrypto/universal-hashes/pull/57
+[#56]: https://github.com/RustCrypto/universal-hashes/pull/56
+[#52]: https://github.com/RustCrypto/universal-hashes/pull/52
+
 ## 0.3.3 (2019-12-21)
 ### Changed
 - Match ideal assembly implementation on x86/x86_64 ([#43], [#44])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -13,9 +13,6 @@ readme = "README.md"
 keywords = ["aes-gcm-siv", "crypto", "universal-hashing"]
 categories = ["cryptography", "no-std"]
 edition = "2018"
-
-[badges]
-maintenance = { status = "passively-maintained" }
 
 [dependencies]
 cfg-if = "0.1"


### PR DESCRIPTION
### Changed
- Bump `universal-hash` dependency to v0.4; MSRV 1.41 ([#52], [#57])
- Rename `result` methods to to `finalize` ([#56])

[#57]: https://github.com/RustCrypto/universal-hashes/pull/57
[#56]: https://github.com/RustCrypto/universal-hashes/pull/56
[#52]: https://github.com/RustCrypto/universal-hashes/pull/52