### PR TITLE
ghash v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "polyval 0.4.0",

--- a/ghash/CHANGES.md
+++ b/ghash/CHANGES.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-06-06)
+### Changed
+- Bump `polyval` dependency to v0.4 ([#59])
+- Bump `universal-hash` dependency to v0.4; MSRV 1.41 ([#52], [#57])
+- Rename `result` methods to to `finalize` ([#56])
+
+[#59]: https://github.com/RustCrypto/universal-hashes/pull/59
+[#57]: https://github.com/RustCrypto/universal-hashes/pull/57
+[#56]: https://github.com/RustCrypto/universal-hashes/pull/56
+[#52]: https://github.com/RustCrypto/universal-hashes/pull/52
+
 ## 0.2.3 (2019-11-14)
 ### Changed
 - Upgrade to `zeroize` 1.0 ([#33])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = """


### PR DESCRIPTION
### Changed
- Bump `polyval` dependency to v0.4 ([#59])
- Bump `universal-hash` dependency to v0.4; MSRV 1.41 ([#52], [#57])
- Rename `result` methods to to `finalize` ([#56])

[#59]: https://github.com/RustCrypto/universal-hashes/pull/59
[#57]: https://github.com/RustCrypto/universal-hashes/pull/57
[#56]: https://github.com/RustCrypto/universal-hashes/pull/56
[#52]: https://github.com/RustCrypto/universal-hashes/pull/52