### PR TITLE
README.md: remove warning (all crates were audited!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 Collection of [Universal Hash Functions][1] written in pure Rust.
 
-## Warnings
-
-Crates in this repository have not yet received any formal cryptographic and
-security reviews.
-
-**USE AT YOUR OWN RISK.**
-
 ## Crates
 
 | Name | Crates.io | Documentation | Build Status |


### PR DESCRIPTION
All three crates in this repo were audited by NCC group:

https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/

While the individual README.mds for each crate were updated to reflect this, it seems the toplevel README.md was missed.