### PR TITLE
Ghash rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ name = "ghash"
 version = "0.3.0"
 dependencies = [
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "polyval 0.4.0",
+ "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["cryptography", "no-std"]
 edition = "2018"
 
 [dependencies]
-polyval = { version = "0.4", path = "../polyval" }
+universal-hash = { version = "0.4", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.1"
 
 [features]
-std = ["polyval/std"]
+std = []

--- a/ghash/benches/ghash.rs
+++ b/ghash/benches/ghash.rs
@@ -2,7 +2,10 @@
 
 extern crate test;
 
-use ghash::{universal_hash::UniversalHash, GHash};
+use ghash::{
+    universal_hash::{NewUniversalHash, UniversalHash},
+    GHash,
+};
 use test::Bencher;
 
 // TODO(tarcieri): move this into the `universal-hash` crate

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -20,18 +20,15 @@
 //! > that these irreducible polynomials are the "reverse" of each other.
 //!
 //! [`polyval`]: https://github.com/RustCrypto/universal-hashes/tree/master/polyval
-
-#![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use polyval::universal_hash;
-
-use core::convert::TryInto;
-use polyval::Polyval;
+pub use universal_hash;
 use universal_hash::{consts::U16, NewUniversalHash, UniversalHash};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
+
+use core::arch::x86_64::*;
 
 /// GHASH keys (16-bytes)
 pub type Key = universal_hash::Key<GHash>;
@@ -48,74 +45,102 @@ pub type Tag = universal_hash::Output<GHash>;
 /// the AES-GCM authenticated encryption cipher.
 #[derive(Clone)]
 #[repr(align(16))]
-pub struct GHash(Polyval);
+pub struct GHash {
+    h: __m128i,
+    y: __m128i,
+}
+
+const BS_MASK1: i64 = 0x00010203_04050607;
+const BS_MASK2: i64 = 0x08090A0B_0C0D0E0F;
 
 impl NewUniversalHash for GHash {
     type KeySize = U16;
 
     /// Initialize GHASH with the given `H` field element
     fn new(h: &Key) -> Self {
-        let mut h = *h;
-        h.reverse();
-
-        #[allow(unused_mut)]
-        let mut h_polyval = mulX_POLYVAL(&h);
-
-        #[cfg(feature = "zeroize")]
-        h.zeroize();
-
-        #[allow(clippy::let_and_return)]
-        let result = GHash(Polyval::new(&h_polyval));
-
-        #[cfg(feature = "zeroize")]
-        h_polyval.zeroize();
-
-        result
+        unsafe {
+            let bs_mask = _mm_set_epi64x(BS_MASK1, BS_MASK2);
+            let h = _mm_loadu_si128(h.as_ptr() as *const _);
+            let h = _mm_shuffle_epi8(h, bs_mask);
+            let y = _mm_setzero_si128();
+            Self { h, y }
+        }
     }
 }
 
 impl UniversalHash for GHash {
     type BlockSize = U16;
 
-    /// Input a field element `X` to be authenticated
+    #[inline]
     fn update(&mut self, x: &Block) {
-        let mut x = *x;
-        x.reverse();
-        self.0.update(&x);
+        unsafe {
+            let bs_mask = _mm_set_epi64x(BS_MASK1, BS_MASK2);
+
+            let h = self.h;
+            let x = _mm_loadu_si128(x.as_ptr() as *const _);
+            let x = _mm_shuffle_epi8(x, bs_mask);
+            let y = _mm_xor_si128(self.y, x);
+
+            let h0 = h;
+            let h1 = _mm_shuffle_epi32(h, 0x0E);
+            let h2 = _mm_xor_si128(h0, h1);
+            let y0 = y;
+            let y1 = _mm_shuffle_epi32(y, 0x0E);
+            let y2 = _mm_xor_si128(y0, y1);
+            let t0 = _mm_clmulepi64_si128(y0, h0, 0x00);
+            let t1 = _mm_clmulepi64_si128(y, h, 0x11);
+            let t2 = _mm_clmulepi64_si128(y2, h2, 0x00);
+            let t2 = _mm_xor_si128(t2, _mm_xor_si128(t0, t1));
+            let v0 = t0;
+            let v1 = _mm_xor_si128(_mm_shuffle_epi32(t0, 0x0E), t2);
+            let v2 = _mm_xor_si128(t1, _mm_shuffle_epi32(t2, 0x0E));
+            let v3 = _mm_shuffle_epi32(t1, 0x0E);
+
+            let v3 = _mm_or_si128(_mm_slli_epi64(v3, 1), _mm_srli_epi64(v2, 63));
+            let v2 = _mm_or_si128(_mm_slli_epi64(v2, 1), _mm_srli_epi64(v1, 63));
+            let v1 = _mm_or_si128(_mm_slli_epi64(v1, 1), _mm_srli_epi64(v0, 63));
+            let v0 = _mm_slli_epi64(v0, 1);
+
+            let v2 = _mm_xor_si128(
+                v2,
+                _mm_xor_si128(
+                    _mm_xor_si128(v0, _mm_srli_epi64(v0, 1)),
+                    _mm_xor_si128(_mm_srli_epi64(v0, 2), _mm_srli_epi64(v0, 7)),
+                ),
+            );
+            let v1 = _mm_xor_si128(
+                _mm_xor_si128(v1, _mm_slli_epi64(v0, 63)),
+                _mm_xor_si128(_mm_slli_epi64(v0, 62), _mm_slli_epi64(v0, 57)),
+            );
+            let v3 = _mm_xor_si128(
+                v3,
+                _mm_xor_si128(
+                    _mm_xor_si128(v1, _mm_srli_epi64(v1, 1)),
+                    _mm_xor_si128(_mm_srli_epi64(v1, 2), _mm_srli_epi64(v1, 7)),
+                ),
+            );
+            let v2 = _mm_xor_si128(
+                _mm_xor_si128(v2, _mm_slli_epi64(v1, 63)),
+                _mm_xor_si128(_mm_slli_epi64(v1, 62), _mm_slli_epi64(v1, 57)),
+            );
+
+            self.y = _mm_unpacklo_epi64(v2, v3);
+        }
     }
 
     /// Reset internal state
     fn reset(&mut self) {
-        self.0.reset();
+        unsafe {
+            self.y = _mm_setzero_si128();
+        }
     }
 
     /// Get GHASH output
     fn finalize(self) -> Tag {
-        let mut output = self.0.finalize().into_bytes();
-        output.reverse();
-        Tag::new(output)
+        unsafe {
+            let bs_mask = _mm_set_epi64x(BS_MASK1, BS_MASK2);
+            core::mem::transmute(_mm_shuffle_epi8(self.y, bs_mask))
+        }
     }
 }
 
-/// The `mulX_POLYVAL()` function as defined in [RFC 8452 Appendix A][1].
-/// Performs a doubling (a.k.a. "multiply by x") over GF(2^128).
-/// This is useful for implementing GHASH in terms of POLYVAL.
-///
-/// [1]: https://tools.ietf.org/html/rfc8452#appendix-A
-#[allow(non_snake_case)]
-fn mulX_POLYVAL(block: &Block) -> Block {
-    let mut v0 = u64::from_le_bytes(block[..8].try_into().unwrap());
-    let mut v1 = u64::from_le_bytes(block[8..].try_into().unwrap());
-
-    let v0h = v0 >> 63;
-    let v1h = v1 >> 63;
-
-    v0 <<= 1;
-    v1 <<= 1;
-    v0 ^= v1h;
-    v1 ^= v0h ^ (v1h << 63) ^ (v1h << 62) ^ (v1h << 57);
-
-    (u128::from(v0) | (u128::from(v1) << 64))
-        .to_le_bytes()
-        .into()
-}

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -38,7 +38,9 @@ impl NewUniversalHash for GHash {
     fn new(h: &Key) -> Self {
         unsafe {
             let bs_mask = _mm_set_epi64x(BS_MASK1, BS_MASK2);
-            let h = _mm_loadu_si128(h.as_ptr() as *const _);
+            // `_mm_loadu_si128` performs an unaligned load
+            #[allow(clippy::cast_ptr_alignment)]
+            let h = _mm_loadu_si128(h.as_ptr() as *const __m128i);
             let h = _mm_shuffle_epi8(h, bs_mask);
             let y = _mm_setzero_si128();
             Self { h, y }
@@ -67,7 +69,9 @@ impl UniversalHash for GHash {
             let bs_mask = _mm_set_epi64x(BS_MASK1, BS_MASK2);
 
             let h = self.h;
-            let x = _mm_loadu_si128(x.as_ptr() as *const _);
+            // `_mm_loadu_si128` performs an unaligned load
+            #[allow(clippy::cast_ptr_alignment)]
+            let x = _mm_loadu_si128(x.as_ptr() as *const __m128i);
             let x = _mm_shuffle_epi8(x, bs_mask);
             let y = _mm_xor_si128(self.y, x);
 

--- a/ghash/tests/lib.rs
+++ b/ghash/tests/lib.rs
@@ -27,17 +27,3 @@ fn ghash_test_vector() {
     let result = ghash.finalize();
     assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
 }
-
-#[test]
-fn ghash_test_vector2() {
-    let mut ghash = GHash::new(&H.into());
-    ghash.update_padded(&hex!(
-        "
-        4f4f95668c83dfb6401762bb2d01a262
-        d1a24ddd2721d006bbe45f20d3c9f362
-    "
-    ));
-
-    let result = ghash.finalize();
-    assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
-}

--- a/ghash/tests/lib.rs
+++ b/ghash/tests/lib.rs
@@ -27,3 +27,17 @@ fn ghash_test_vector() {
     let result = ghash.finalize();
     assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
 }
+
+#[test]
+fn ghash_test_vector2() {
+    let mut ghash = GHash::new(&H.into());
+    ghash.update_padded(&hex!(
+        "
+        4f4f95668c83dfb6401762bb2d01a262
+        d1a24ddd2721d006bbe45f20d3c9f362
+    "
+    ));
+
+    let result = ghash.finalize();
+    assert_eq!(&GHASH_RESULT[..], result.into_bytes().as_slice());
+}


### PR DESCRIPTION
For now it's just an experiment on optimizing GHASH, later I will attempt to add runtime detection based on `cpuid-bool`. The code is based on BoringSSL. It outperforms current version 1667 vs 1383 MB/s. It's possible to optimize it a bit further by explicitly implementing `update_padded` and moving load/store of `y` and `h` outside of the chunk loop, but I don't like such boilerplate. Ideally compiler should be able to do it itself, but I guess it's blocked by the LLVM aliasing bug.

I am not sure if it will be possible to keep both performance and shared code between `ghash` and `polyval`.