### PR TITLE
.github: use latest Tarpaulin; bump codecov-action

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
       - README.md
 
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
@@ -72,16 +76,12 @@ jobs:
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
-        env:
-          CARGO_INCREMENTAL: 0
         with:
-          version: 0.12.4
+          version: latest
           args: --all -- --test-threads 1
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v1.0.13
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
No longer needs a `CODECOV_TOKEN`