### PR TITLE
poly1305 v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "hex-literal",
  "universal-hash",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2020-09-29)
+### Added
+- AVX2 backend ([#49])
+
+[#49]: https://github.com/RustCrypto/universal-hashes/pull/49
+
 ## 0.6.0 (2020-06-06)
 ### Added
 - `Poly1305::compute_unpadded` for XSalsa20Poly1305 ([#55])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"

--- a/poly1305/README.md
+++ b/poly1305/README.md
@@ -20,8 +20,10 @@ In practice, Poly1305 is primarily combined with ciphers from the
 This crate has received one [security audit by NCC Group][7], with no significant
 findings. We would like to thank [MobileCoin][8] for funding the audit.
 
+NOTE: the audit predates the AVX2 backend, which has not yet been audited.
+
 All implementations contained in the crate are designed to execute in constant
-time, either by relying on hardware intrinsics (i.e. AVX2 on x86/x86_64), or
+time, either by relying on hardware intrinsics (e.g. AVX2 on x86/x86_64), or
 using a portable implementation which is only constant time on processors which
 implement constant-time multiplication.
 

--- a/poly1305/src/lib.rs
+++ b/poly1305/src/lib.rs
@@ -1,10 +1,59 @@
-//! The Poly1305 universal hash function and message authentication code
-
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+//! The Poly1305 universal hash function and message authentication code.
+//!
+//! # About
+//!
+//! Poly1305 is a universal hash function suitable for use as a one-time
+//! authenticator and, when combined with a cipher, a message authentication
+//! code (MAC).
+//!
+//! It takes a 32-byte one-time key and a message and produces a 16-byte tag,
+//! which can be used to authenticate the message.
+//!
+//! Poly1305 is primarily notable for its use in the [`ChaCha20Poly1305`] and
+//! [`XSalsa20Poly1305`] authenticated encryption algorithms.
+//!
+//! # Minimum Supported Rust Version
+//!
+//! Rust **1.41** or higher.
+//!
+//! Minimum supported Rust version may be changed in the future, but such
+//! changes will be accompanied with a minor version bump.
+//!
+//! # Performance Notes
+//!
+//! For maximum performance on x86/x86_64 CPUs, we recommend enabling the AVX2
+//! backend using the following `RUSTFLAGS`:
+//!
+//! - x86(-64) CPU: `target-cpu=haswell` or newer
+//! - AVX2: `target-feature=+avx2`
+//!
+//! Example:
+//!
+//! ```text
+//! $ RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+avx2" cargo bench
+//! ```
+//!
+//! # Security Notes
+//!
+//! This crate has received one [security audit by NCC Group][audit], with no
+//! significant findings. We would like to thank [MobileCoin] for funding the
+//! audit.
+//!
+//! NOTE: the audit predates the AVX2 backend, which has not yet been audited.
+//!
+//! All implementations contained in the crate are designed to execute in constant
+//! time, either by relying on hardware intrinsics (e.g. AVX2 on x86/x86_64), or
+//! using a portable implementation which is only constant time on processors which
+//! implement constant-time multiplication.
+//!
+//! It is not suitable for use on processors with a variable-time multiplication
+//! operation (e.g. short circuit on multiply-by-zero / multiply-by-one, such as
+//! certain 32-bit PowerPC CPUs and some non-ARM microcontrollers).
+//!
+//! [`ChaCha20Poly1305`]: https://docs.rs/chacha20poly1305
+//! [`XSalsa20Poly1305`]: https://docs.rs/xsalsa20poly1305
+//! [audit]: https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/
+//! [MobileCoin]: https://mobilecoin.com
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]


### PR DESCRIPTION
### Added
- AVX2 backend ([#49])

[#49]: https://github.com/RustCrypto/universal-hashes/pull/49