### PR TITLE
polyval v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cfg-if",
  "hex-literal",

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2020-11-25)
+### Added
+- `KEY_SIZE` constant ([#82])
+
+### Changed
+- Bump `cfg-if` from v0.1 to v1.0.0 ([#86])
+
+[#86]: https://github.com/RustCrypto/universal-hashes/pull/86
+[#82]: https://github.com/RustCrypto/universal-hashes/pull/82
+
 ## 0.4.1 (2020-09-26)
 ### Changed
 - Performance improvements ([#75])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- `KEY_SIZE` constant ([#82])

### Changed
- Bump `cfg-if` from v0.1 to v1.0.0 ([#86])

[#86]: https://github.com/RustCrypto/universal-hashes/pull/86
[#82]: https://github.com/RustCrypto/universal-hashes/pull/82