### PR TITLE
poly1305 v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cpuid-bool",
  "hex-literal",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2020-12-09)
+### Added
+- Runtime AVX2 detection ([#97])
+
+[#97]: https://github.com/RustCrypto/universal-hashes/pull/97
+
 ## 0.6.1 (2020-09-29)
 ### Added
 - AVX2 backend ([#49])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Added
- AVX2 backend ([#49])

[#49]: https://github.com/RustCrypto/universal-hashes/pull/49