### PR TITLE
polyval: fix `zeroize` feature on autodetect backend

### DIFF
--- a/polyval/src/autodetect.rs
+++ b/polyval/src/autodetect.rs
@@ -90,3 +90,13 @@ impl Clone for Polyval {
         }
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl Drop for Polyval {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        const SIZE: usize = core::mem::size_of::<Polyval>();
+        let state = unsafe { &mut *(self as *mut Polyval as *mut [u8; SIZE]) };
+        state.zeroize();
+    }
+}

--- a/polyval/src/backend/soft32.rs
+++ b/polyval/src/backend/soft32.rs
@@ -25,6 +25,8 @@
 //! In other words, if we bit-reverse (over 32 bits) the operands, then we
 //! bit-reverse (over 64 bits) the result.
 
+// TODO(tarcieri): fix zeroize when we switch to ManuallyDrop on MSRV 1.49+
+
 use crate::{Block, Key};
 use core::{
     convert::TryInto,

--- a/polyval/src/backend/soft64.rs
+++ b/polyval/src/backend/soft64.rs
@@ -5,6 +5,8 @@
 //!
 //! Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
 
+// TODO(tarcieri): fix zeroize when we switch to ManuallyDrop on MSRV 1.49+
+
 use crate::{Block, Key};
 use core::{
     convert::TryInto,


### PR DESCRIPTION
Adds a `Drop` impl for the autodetect backend which zeroizes when the `zeroize` feature is enabled.

Due to the need for union members to be `Copy` until we can leverage `ManuallyDrop` on MSRV 1.49+, the `soft` backends still don't implement it properly.

This commit also adds a TODO to fix that when we bump MSRV.