### PR TITLE
ghash: use `polyval::mulx`

### DIFF
--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "0.4", path = "../polyval" }
+polyval = { version = "0.4.4", features = ["mulx"], path = "../polyval" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/ghash/tests/lib.rs
+++ b/ghash/tests/lib.rs
@@ -1,10 +1,8 @@
-#[macro_use]
-extern crate hex_literal;
-
 use ghash::{
     universal_hash::{NewUniversalHash, UniversalHash},
     GHash,
 };
+use hex_literal::hex;
 
 //
 // Test vectors for GHASH from RFC 8452 Appendix A

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -4,13 +4,13 @@
     any(target_arch = "x86", target_arch = "x86_64"),
     not(feature = "force-soft")
 ))]
-pub(crate) mod clmul;
+pub(crate) mod autodetect;
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     not(feature = "force-soft")
 ))]
-pub(crate) mod autodetect;
+pub(crate) mod clmul;
 
 #[cfg_attr(not(target_pointer_width = "64"), path = "backend/soft32.rs")]
 #[cfg_attr(target_pointer_width = "64", path = "backend/soft64.rs")]


### PR DESCRIPTION
The `ghash` crate is implemented in terms of POLYVAL using a technique described in RFC 8452 Appendix A.

Part of this implementation is a multiply-by-x operation over POLYVAL field elements (a.k.a. `mulX_POLYVAL` in RFC 8452 terminology), which was previously defined in the `ghash` crate itself.

However, this function was just added to the `polyval` crate in #107, so the `ghash` crate can now use that implementation.