### PR TITLE
ghash v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex-literal",
  "opaque-debug",

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 (2020-12-26)
+### Added
+- `Debug` impl using `opaque-debug` ([#105])
+
+### Changed
+- Use `polyval::mulx` ([#109])
+
+[#105]: https://github.com/RustCrypto/universal-hashes/pull/105
+[#109]: https://github.com/RustCrypto/universal-hashes/pull/109
+
 ## 0.3.0 (2020-06-06)
 ### Changed
 - Bump `polyval` dependency to v0.4 ([#59])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["RustCrypto Developers"]
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0 OR MIT"
 description = """
 Universal hash over GF(2^128) useful for constructing a Message Authentication Code (MAC),
 as in the AES-GCM authenticated encryption cipher.

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.4 (2020-12-26)
 ### Added
+- `Debug` impl using `opaque-debug` ([#105])
 - `mulx` feature ([#107])
 
+[#105]: https://github.com/RustCrypto/universal-hashes/pull/105
 [#107]: https://github.com/RustCrypto/universal-hashes/pull/107
 
 ## 0.4.3 (2020-12-08)


### PR DESCRIPTION
### Added
- `Debug` impl using `opaque-debug` ([#105])

### Changed
- Use `polyval::mulx` ([#109])

[#105]: https://github.com/RustCrypto/universal-hashes/pull/105
[#109]: https://github.com/RustCrypto/universal-hashes/pull/109