### PR TITLE
polyval v0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "cpuid-bool",
  "hex-literal",

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.5 (2020-12-26)
+### Changed
+- Use `u128` to impl `mulx` ([#111])
+
+[#111]: https://github.com/RustCrypto/universal-hashes/pull/111
+
 ## 0.4.4 (2020-12-26)
 ### Added
 - `Debug` impl using `opaque-debug` ([#105])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Use `u128` to impl `mulx` ([#111])

[#111]: https://github.com/RustCrypto/universal-hashes/pull/111