### PR TITLE
polyval: use ManuallyDrop unions; MSRV 1.49+

### DIFF
--- a/.github/workflows/ghash.yml
+++ b/.github/workflows/ghash.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -60,7 +60,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -89,7 +89,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -97,7 +97,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -125,7 +125,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -133,7 +133,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -159,13 +159,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.0-pre"
 dependencies = [
  "hex-literal",
  "opaque-debug",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.0-pre"
 dependencies = [
  "cpuid-bool",
  "hex-literal",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "0.4.4", features = ["mulx"], path = "../polyval" }
+polyval = { version = "=0.5.0-pre", features = ["mulx"], path = "../polyval" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 opaque-debug = "0.3"
 universal-hash = { version = "0.4", default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
+zeroize = { version = "1.2", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpuid-bool = "0.2"

--- a/polyval/README.md
+++ b/polyval/README.md
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/polyval/badge.svg
 [docs-link]: https://docs.rs/polyval/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [build-image]: https://github.com/RustCrypto/universal-hashes/workflows/polyval/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/universal-hashes/actions?query=workflow%3Apolyval
 

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -13,13 +13,6 @@ use core::arch::x86_64::*;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[derive(Clone)]
-#[cfg_attr(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        not(feature = "force-soft")
-    ),
-    derive(Copy)
-)] // TODO(tarcieri): switch to ManuallyDrop on MSRV 1.49+
 pub struct Polyval {
     h: __m128i,
     y: __m128i,
@@ -124,6 +117,15 @@ impl Polyval {
         );
 
         self.y = _mm_unpacklo_epi64(v2, v3);
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for Polyval {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.h.zeroize();
+        self.y.zeroize();
     }
 }
 


### PR DESCRIPTION
Using `ManuallyDrop` for the fields of `union`s (allowing them to be non-Copy types) was stabilized in Rust 1.49.