### PR TITLE
poly1305: use ManuallyDrop unions; MSRV 1.49+

### DIFF
--- a/.github/workflows/poly1305.yml
+++ b/.github/workflows/poly1305.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -58,7 +58,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -86,7 +86,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -94,7 +94,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -121,7 +121,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -129,7 +129,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -154,13 +154,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41.0
+        toolchain: 1.49.0
         components: clippy
     - run: cargo clippy --all --all-features -- -D warnings
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collection of [Universal Hash Functions][1] written in pure Rust.
 
 ### Minimum Supported Rust Version
 
-All crates in this repository support **Rust 1.41** or higher.
+All crates in this repository support **Rust 1.49** or higher.
 
 In the future, we reserve the right to change the Minimum Supported Rust
 Version, but it will be done with the minor version bump.
@@ -39,7 +39,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 
 [//]: # (crates)
 

--- a/ghash/README.md
+++ b/ghash/README.md
@@ -49,7 +49,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ghash/badge.svg
 [docs-link]: https://docs.rs/ghash/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [build-image]: https://github.com/RustCrypto/universal-hashes/workflows/ghash/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/universal-hashes/actions?query=workflow%3Aghash
 

--- a/poly1305/README.md
+++ b/poly1305/README.md
@@ -53,7 +53,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/poly1305/badge.svg
 [docs-link]: https://docs.rs/poly1305/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [build-image]: https://github.com/RustCrypto/universal-hashes/workflows/poly1305/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/universal-hashes/actions?query=workflow%3Apoly1305
 

--- a/poly1305/src/backend/avx2.rs
+++ b/poly1305/src/backend/avx2.rs
@@ -30,7 +30,7 @@ struct Initialized {
     r4: PrecomputedMultiplier,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub(crate) struct State {
     k: AdditionKey,
     r1: PrecomputedMultiplier,

--- a/poly1305/src/backend/soft.rs
+++ b/poly1305/src/backend/soft.rs
@@ -12,14 +12,10 @@
 // ...and was originally a port of Andrew Moons poly1305-donna
 // https://github.com/floodyberry/poly1305-donna
 
+use crate::{Block, Key, Tag};
 use core::convert::TryInto;
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
-use crate::{Block, Key, Tag};
-
-#[derive(Copy, Clone, Default)]
+#[derive(Clone, Default)]
 pub(crate) struct State {
     r: [u32; 5],
     h: [u32; 5],
@@ -237,8 +233,9 @@ impl State {
 }
 
 #[cfg(feature = "zeroize")]
-impl Zeroize for State {
-    fn zeroize(&mut self) {
+impl Drop for State {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
         self.r.zeroize();
         self.h.zeroize();
         self.pad.zeroize();

--- a/poly1305/src/lib.rs
+++ b/poly1305/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Minimum Supported Rust Version
 //!
-//! Rust **1.41** or higher.
+//! Rust **1.49** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but such
 //! changes will be accompanied with a minor version bump.

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -84,14 +84,12 @@ impl UniversalHash for Polyval {
 impl Clone for Polyval {
     fn clone(&self) -> Self {
         let inner = if self.token.get() {
-            let clmul = unsafe { (*self.inner.clmul).clone() };
             Inner {
-                clmul: ManuallyDrop::new(clmul),
+                clmul: ManuallyDrop::new(unsafe { (*self.inner.clmul).clone() }),
             }
         } else {
-            let soft = unsafe { (*self.inner.soft).clone() };
             Inner {
-                soft: ManuallyDrop::new(soft),
+                soft: ManuallyDrop::new(unsafe { (*self.inner.soft).clone() }),
             }
         };
 

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust *1.41* or higher.
+//! Rust *1.49* or higher.
 //!
 //! In the future the minimum supported Rust version may be changed, but it
 //! be will be accompanied with a minor version bump.


### PR DESCRIPTION
Using `ManuallyDrop` for the fields of `union`s (allowing them to be non-Copy types) was stabilized in Rust 1.49.