### PR TITLE
poly1305 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cpufeatures",
  "hex-literal",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Changed
+- Use `ManuallyDrop` unions; MSRV 1.49+ ([#114])
+- Use `cpufeatures` v0.1 crate release ([#116])
+
+[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
+[#116]: https://github.com/RustCrypto/universal-hashes/pull/116
+
 ## 0.6.2 (2020-12-09)
 ### Added
 - Runtime AVX2 detection ([#97])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Changed
- Use `ManuallyDrop` unions; MSRV 1.49+ ([#114])
- Use `cpufeatures` v0.1 crate release ([#116])

[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
[#116]: https://github.com/RustCrypto/universal-hashes/pull/116