### PR TITLE
polyval: remove `mulx` feature

### DIFF
--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -40,9 +40,8 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
       - run: cargo build --target ${{ matrix.target }} --release --features force-soft
-      - run: cargo build --target ${{ matrix.target }} --release --features mulx
       - run: cargo build --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --features force-soft,mulx,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --features force-soft,zeroize
 
   # Tests with CPU feature detection enabled
   autodetect:
@@ -74,7 +73,6 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features mulx
       - run: cargo test --target ${{ matrix.target }} --release --features std
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --features std,zeroize
@@ -112,7 +110,6 @@ jobs:
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --target ${{ matrix.target }} --release
       - run: cargo test --target ${{ matrix.target }} --release --features force-soft
-      - run: cargo test --target ${{ matrix.target }} --release --features mulx
       - run: cargo test --target ${{ matrix.target }} --release --features std
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
@@ -147,7 +144,6 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --target ${{ matrix.target }} --release --features force-soft
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft,mulx
       - run: cargo test --target ${{ matrix.target }} --release --features force-soft,std
       - run: cargo test --target ${{ matrix.target }} --release --features force-soft,zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
@@ -182,7 +178,6 @@ jobs:
       - run: cargo install cross
       - run: cross test --target ${{ matrix.target }} --release
       - run: cross test --target ${{ matrix.target }} --release --features force-soft
-      - run: cross test --target ${{ matrix.target }} --release --features mulx
       - run: cross test --target ${{ matrix.target }} --release --features std
       - run: cross test --target ${{ matrix.target }} --release --features zeroize
       - run: cross test --target ${{ matrix.target }} --release --all-features

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "=0.5.0-pre", features = ["mulx"], path = "../polyval" }
+polyval = { version = "=0.5.0-pre", path = "../polyval" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -27,7 +27,6 @@ hex-literal = "0.2"
 
 [features]
 force-soft = [] # Disable support for hardware intrinsics (CLMUL)
-mulx = []
 std = ["universal-hash/std"]
 
 [package.metadata.docs.rs]

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -59,16 +59,10 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 mod backend;
-
-#[cfg(feature = "mulx")]
 mod mulx;
 
+pub use crate::{backend::Polyval, mulx::mulx};
 pub use universal_hash;
-
-pub use crate::backend::Polyval;
-
-#[cfg(feature = "mulx")]
-pub use crate::mulx::mulx;
 
 opaque_debug::implement!(Polyval);
 

--- a/polyval/src/mulx.rs
+++ b/polyval/src/mulx.rs
@@ -8,7 +8,6 @@ use crate::Block;
 /// This is useful for implementing GHASH in terms of POLYVAL.
 ///
 /// [1]: https://tools.ietf.org/html/rfc8452#appendix-A
-#[cfg_attr(docsrs, doc(cfg(feature = "mulx")))]
 pub fn mulx(block: &Block) -> Block {
     let mut v = u128::from_le_bytes((*block).into());
     let v_hi = v >> 127;


### PR DESCRIPTION
There's really no reason this needs its own crate feature. Instead it is now a standard part of this crate's API.