### PR TITLE
polyval v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "cpufeatures",
  "hex-literal",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "=0.5.0-pre", path = "../polyval" }
+polyval = { version = "0.5", path = "../polyval" }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-04-29)
+### Changed
+- Use `ManuallyDrop` unions; MSRV 1.49+ ([#113], [#114])
+- Replace `cpuid-bool` with `cpufeatures` ([#116])
+
+### Removed
+- `mulx` feature: now always built-in ([#118])
+
+[#113]: https://github.com/RustCrypto/universal-hashes/pull/113
+[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
+[#116]: https://github.com/RustCrypto/universal-hashes/pull/116
+[#118]: https://github.com/RustCrypto/universal-hashes/pull/118
+
 ## 0.4.5 (2020-12-26)
 ### Changed
 - Use `u128` to impl `mulx` ([#111])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.5.0-pre"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Use `ManuallyDrop` unions; MSRV 1.49+ ([#113], [#114])
- Replace `cpuid-bool` with `cpufeatures` ([#116])

### Removed
- `mulx` feature: now always built-in ([#118])

[#113]: https://github.com/RustCrypto/universal-hashes/pull/113
[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
[#116]: https://github.com/RustCrypto/universal-hashes/pull/116
[#118]: https://github.com/RustCrypto/universal-hashes/pull/118