### PR TITLE
ghash v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "hex-literal",
  "opaque-debug",

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-04-29)
+### Changed
+- Bump `polyval` crate dependency to v0.5; MSRV 1.49+ ([#114], [#119])
+
+[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
+[#119]: https://github.com/RustCrypto/universal-hashes/pull/119
+
 ## 0.3.1 (2020-12-26)
 ### Added
 - `Debug` impl using `opaque-debug` ([#105])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Bump `polyval` crate dependency to v0.5; MSRV 1.49+ ([#114], [#119])

[#114]: https://github.com/RustCrypto/universal-hashes/pull/114
[#119]: https://github.com/RustCrypto/universal-hashes/pull/119