### PR TITLE
ghash v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "hex-literal",
  "opaque-debug",

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2021-05-31)
+### Added
+- Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#126])
+
+[#126]: https://github.com/RustCrypto/universal-hashes/pull/126
+
 ## 0.4.1 (2021-05-05)
 ### Added
 - `force-soft` feature ([#121])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#126])

[#126]: https://github.com/RustCrypto/universal-hashes/pull/126