### PR TITLE
Pin zeroize to v1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,17 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "hex-literal",
  "opaque-debug",
@@ -38,15 +39,15 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76505e26b6ca3bbdbbb360b68472abbb80998c5fa5dc43672eca34f28258e138"
+checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "opaque-debug"
@@ -56,7 +57,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "poly1305"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -67,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -79,25 +80,31 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "zeroize"

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.3 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#132])
+
+[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+
 ## 0.4.2 (2021-05-31)
 ### Added
 - Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#126])

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.3 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#132])
+- Pin `zeroize` dependency to v1.3 ([#134])
 
-[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+[#134]: https://github.com/RustCrypto/universal-hashes/pull/134
 
 ## 0.4.2 (2021-05-31)
 ### Added

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 opaque-debug = "0.3"
 polyval = { version = "0.5.1", path = "../polyval" }
-zeroize = { version = "1", optional = true, default-features = false }
+zeroize = { version = "=1.3", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -24,8 +24,9 @@
 
 #![no_std]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/ghash/0.4.3"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.1 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#132])
+- Pin `zeroize` dependency to v1.3 ([#134])
 
-[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+[#134]: https://github.com/RustCrypto/universal-hashes/pull/134
 
 ## 0.7.0 (2021-04-29)
 ### Changed

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#132])
+
+[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+
 ## 0.7.0 (2021-04-29)
 ### Changed
 - Use `ManuallyDrop` unions; MSRV 1.49+ ([#114])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.7.0"
+version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 opaque-debug = "0.3"
 universal-hash = { version = "0.4", default-features = false }
-zeroize = { version = "1", optional = true, default-features = false }
+zeroize = { version = "=1.3", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.1"

--- a/poly1305/src/lib.rs
+++ b/poly1305/src/lib.rs
@@ -42,7 +42,11 @@
 //! [MobileCoin]: https://mobilecoin.com
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/poly1305/0.7.1"
+)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (2021-07-20)
+### Changed
+- Pin `zeroize` dependency to v1.3 ([#132])
+
+[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+
 ## 0.5.1 (2021-05-31)
 ### Added
 - Nightly-only ARMv8 intrinsics support gated under the `armv8` feature ([#126])

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.2 (2021-07-20)
 ### Changed
-- Pin `zeroize` dependency to v1.3 ([#132])
+- Pin `zeroize` dependency to v1.3 ([#134])
 
-[#132]: https://github.com/RustCrypto/universal-hashes/pull/132
+[#134]: https://github.com/RustCrypto/universal-hashes/pull/134
 
 ## 0.5.1 (2021-05-31)
 ### Added

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -18,7 +18,7 @@ edition = "2018"
 cfg-if = "1"
 opaque-debug = "0.3"
 universal-hash = { version = "0.4", default-features = false }
-zeroize = { version = "1.3", optional = true, default-features = false }
+zeroize = { version = "=1.3", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.1.5"

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -80,8 +80,9 @@
     feature(stdsimd, aarch64_target_feature)
 )]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/polyval/0.5.2"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
Also updates Cargo.lock and makes the `#![doc(...)]` attribute consistent across crates.