### PR TITLE
polyval: remove use of ARMv8 `crypto` feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+**/Cargo.lock

--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -68,7 +68,6 @@ impl Polyval {
     // TODO(tarcieri): investigate ordering optimizations and fusions e.g.`fuse-crypto-eor`
     #[inline]
     #[target_feature(enable = "neon")]
-    #[target_feature(enable = "crypto")]
     unsafe fn mul(&mut self, x: &Block) {
         let h = self.h;
         let y = veorq_u8(self.y, vld1q_u8(x.as_ptr()));


### PR DESCRIPTION
It was removed from the nightly compiler:

https://github.com/rust-lang/rust/pull/87729