### PR TITLE
poly1305 v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "poly1305"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cpufeatures",
  "hex-literal",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2021-08-27)
+### Changed
+- Bump `cpufeatures` dependency to v0.2 ([#136])
+
+[#136]: https://github.com/RustCrypto/universal-hashes/pull/136
+
 ## 0.7.1 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#134])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.7.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.2" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 opaque-debug = "0.3"
 universal-hash = { version = "0.4", default-features = false }
-zeroize = { version = "=1.3", optional = true, default-features = false }
+zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"


### PR DESCRIPTION
### Changed
- Bump `cpufeatures` dependency to v0.2 ([#136])

[#136]: https://github.com/RustCrypto/universal-hashes/pull/136