### PR TITLE
polyval v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.3 (2021-08-27)
+### Changed
+- Bump `cpufeatures` dependency to v0.2 ([#136], [#138])
+- Remove use of ARMv8 `crypto` feature ([#137])
+
+[#136]: https://github.com/RustCrypto/universal-hashes/pull/136
+[#137]: https://github.com/RustCrypto/universal-hashes/pull/137
+[#138]: https://github.com/RustCrypto/universal-hashes/pull/138
+
 ## 0.5.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#134])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.5.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -18,7 +18,7 @@ edition = "2018"
 cfg-if = "1"
 opaque-debug = "0.3"
 universal-hash = { version = "0.4", default-features = false }
-zeroize = { version = "=1.3", optional = true, default-features = false }
+zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -82,7 +82,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/polyval/0.5.2"
+    html_root_url = "https://docs.rs/polyval/0.5.3"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
### Changed
- Bump `cpufeatures` dependency to v0.2 ([#136], [#138])
- Remove use of ARMv8 `crypto` feature ([#137])

[#136]: https://github.com/RustCrypto/universal-hashes/pull/136
[#137]: https://github.com/RustCrypto/universal-hashes/pull/137
[#138]: https://github.com/RustCrypto/universal-hashes/pull/138