### PR TITLE
ghash: relax zeroize constraints

### DIFF
--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -17,7 +17,9 @@ edition = "2018"
 [dependencies]
 opaque-debug = "0.3"
 polyval = { version = "0.5.1", path = "../polyval" }
-zeroize = { version = "=1.3", optional = true, default-features = false }
+
+# optional dependencies
+zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"


### PR DESCRIPTION
Allows all 1.0 versions of `zeroize` earlier than 1.4 (MSRV 1.51+)