### PR TITLE
ghash v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "hex-literal",
  "opaque-debug",

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2021-08-27)
+### Changed
+- Relax `zeroize` constraints ([#141])
+
+[#141]: https://github.com/RustCrypto/universal-hashes/pull/141
+
 ## 0.4.3 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#134])

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.4.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.4" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Relax `zeroize` constraints ([#141])

[#141]: https://github.com/RustCrypto/universal-hashes/pull/141