### PR TITLE
polyval: remove sse4.1 requirement

### DIFF
--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Remove `sse4.1` from CPU feature requirements for PCLMUL backend ([#143])
+
+[#143]: https://github.com/RustCrypto/universal-hashes/pull/143
+
+
 ## 0.5.3 (2021-08-27)
 ### Changed
 - Bump `cpufeatures` dependency to v0.2 ([#136], [#138])

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -15,7 +15,7 @@ use super::clmul as intrinsics;
 cpufeatures::new!(mul_intrinsics, "aes"); // `aes` implies PMULL
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-cpufeatures::new!(mul_intrinsics, "pclmulqdq", "sse4.1");
+cpufeatures::new!(mul_intrinsics, "pclmulqdq");
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 pub struct Polyval {

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -58,7 +58,6 @@ impl UniversalHash for Polyval {
 impl Polyval {
     #[inline]
     #[target_feature(enable = "pclmulqdq")]
-    #[target_feature(enable = "sse4.1")]
     unsafe fn mul(&mut self, x: &Block) {
         let h = self.h;
 


### PR DESCRIPTION
As far as I can see none of the intrinsics used in the `mul` method require SSE4.1. inspecting generated assembly with this change does not show any uninlined intrinsics.