### PR TITLE
CI: fix workspace `override` directives; remove codecov

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,9 +20,10 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        profile: minimal
         toolchain: 1.56.1
         components: clippy
+        profile: minimal
+        override: true
     - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:
@@ -34,10 +35,10 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
-
+          profile: minimal
+          override: true
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -50,51 +51,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-      - run: cargo +nightly build --benches
-
-  codecov:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-coverage-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+          profile: minimal
           override: true
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: latest
-          args: --all -- --test-threads 1
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.13
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
+      - run: cargo +nightly build --benches


### PR DESCRIPTION
The lack of override directives in the workspace config means newer rustc versions than intended are being used which breaks the build: #149

Codecov hasn't been terribly helpful and adds to build times / spam. This commit removes it.