### PR TITLE
polyval: use stable `aarch64_target_feature`

### DIFF
--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -188,7 +188,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            rust: nightly-2022-03-01
+            rust: nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -75,10 +75,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(
-    all(feature = "armv8", target_arch = "aarch64"),
-    feature(stdsimd, aarch64_target_feature)
-)]
+#![cfg_attr(all(feature = "armv8", target_arch = "aarch64"), feature(stdsimd))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",


### PR DESCRIPTION
Removes the explicit `feature` annotation since the feature has been stabilized now.

Also unpins nightly, which was previously pinned as changes relating to `aarch64_target_feature` were causing nightly breakages. Everything's good to go now, though!