### PR TITLE
polyval: impl `Reset`

### DIFF
--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -6,7 +6,7 @@ use core::mem::ManuallyDrop;
 use universal_hash::{
     consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser},
-    KeyInit, UniversalHash,
+    KeyInit, Reset, UniversalHash,
 };
 
 #[cfg(all(target_arch = "aarch64", feature = "armv8"))]
@@ -98,6 +98,16 @@ impl Clone for Polyval {
         Self {
             inner,
             token: self.token,
+        }
+    }
+}
+
+impl Reset for Polyval {
+    fn reset(&mut self) {
+        if self.token.get() {
+            unsafe { (*self.inner.intrinsics).reset() }
+        } else {
+            unsafe { (*self.inner.soft).reset() }
         }
     }
 }

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -5,7 +5,7 @@ use crate::{Block, Key, Tag};
 use universal_hash::{
     consts::{U1, U16},
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
-    KeyInit, UhfBackend,
+    KeyInit, Reset, UhfBackend,
 };
 
 #[cfg(target_arch = "x86")]
@@ -121,6 +121,14 @@ impl Polyval {
         );
 
         self.y = _mm_unpacklo_epi64(v2, v3);
+    }
+}
+
+impl Reset for Polyval {
+    fn reset(&mut self) {
+        unsafe {
+            self.y = _mm_setzero_si128();
+        }
     }
 }
 

--- a/polyval/src/backend/soft32.rs
+++ b/polyval/src/backend/soft32.rs
@@ -33,7 +33,7 @@ use core::{
 use universal_hash::{
     consts::{U1, U16},
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
-    KeyInit, UhfBackend, UniversalHash,
+    KeyInit, Reset, UhfBackend, UniversalHash,
 };
 
 #[cfg(feature = "zeroize")]
@@ -98,6 +98,12 @@ impl UniversalHash for Polyval {
         }
 
         block
+    }
+}
+
+impl Reset for Polyval {
+    fn reset(&mut self) {
+        self.s = U32x4::default();
     }
 }
 

--- a/polyval/src/backend/soft64.rs
+++ b/polyval/src/backend/soft64.rs
@@ -13,7 +13,7 @@ use core::{
 use universal_hash::{
     consts::{U1, U16},
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
-    KeyInit, UhfBackend, UniversalHash,
+    KeyInit, Reset, UhfBackend, UniversalHash,
 };
 
 #[cfg(feature = "zeroize")]
@@ -75,6 +75,12 @@ impl UniversalHash for Polyval {
         }
 
         block
+    }
+}
+
+impl Reset for Polyval {
+    fn reset(&mut self) {
+        self.s = U64x2::default();
     }
 }
 


### PR DESCRIPTION
This is useful in the implementation of `aes-gcm-siv`, as it allows for calling the newly re-added `finalize_reset` method, which is useful to avoid consuming `self` when computing the tag.

SIV mode encryption requires first computing the tag as a pass of POLYVAL over the plaintext, where the tag also functions as a synthetic initialization vector. With AES-GCM-SIV specifically, it also needs access to the original nonce, which is XORed into the tag.

Consuming `self` means it's not possible to store the cipher, POLYVAL, and nonce in the same struct, since after computing the SIV tag it needs to be passed to the cipher.