### PR TITLE
Replace `armv8`/`force-soft` features with `cfg` attributes

### DIFF
--- a/.github/workflows/poly1305.yml
+++ b/.github/workflows/poly1305.yml
@@ -40,7 +40,6 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
-      - run: cargo build --target ${{ matrix.target }} --release --features force-soft
       - run: cargo build --target ${{ matrix.target }} --release --features zeroize
 
   # Tests for runtime AVX2 detection
@@ -109,13 +108,14 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft
       - run: cargo test --target ${{ matrix.target }} --release --features std
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Tests for the portable software backend
   soft:
+    env:
+      RUSTFLAGS: "-Dwarnings --cfg poly1305_force_soft"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -143,9 +143,9 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft,std
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft,zeroize
+      - run: cargo test --target ${{ matrix.target }} --release
+      - run: cargo test --target ${{ matrix.target }} --release --features std
+      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Cross-compiled tests
@@ -168,6 +168,5 @@ jobs:
           override: true
       - run: cargo install cross
       - run: cross test --target ${{ matrix.target }} --release
-      - run: cross test --target ${{ matrix.target }} --release --features force-soft
       - run: cross test --target ${{ matrix.target }} --release --features std
       - run: cross test --target ${{ matrix.target }} --release --all-features

--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -40,9 +40,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --target ${{ matrix.target }} --release
-      - run: cargo build --target ${{ matrix.target }} --release --features force-soft
       - run: cargo build --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --features force-soft,zeroize
 
   # Tests with CPU feature detection enabled
   autodetect:
@@ -110,13 +108,14 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
       - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft
       - run: cargo test --target ${{ matrix.target }} --release --features std
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Tests for the portable software backend (forced)
   soft:
+    env:
+      RUSTFLAGS: "-Dwarnings --cfg polyval_force_soft"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -144,9 +143,9 @@ jobs:
           override: true
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft,std
-      - run: cargo test --target ${{ matrix.target }} --release --features force-soft,zeroize
+      - run: cargo test --target ${{ matrix.target }} --release
+      - run: cargo test --target ${{ matrix.target }} --release --features std
+      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Cross-compiled tests
@@ -169,12 +168,14 @@ jobs:
           override: true
       - run: cargo install cross
       - run: cross test --target ${{ matrix.target }} --release
-      - run: cross test --target ${{ matrix.target }} --release --features force-soft
       - run: cross test --target ${{ matrix.target }} --release --features std
       - run: cross test --target ${{ matrix.target }} --release --features zeroize
+      - run: cross test --target ${{ matrix.target }} --release --all-features
 
   # ARMv8 cross-compiled tests for PMULL intrinsics (nightly-only)
   armv8:
+    env:
+      RUSTFLAGS: "-Dwarnings --cfg polyval_armv8"
     strategy:
       matrix:
         include:
@@ -191,8 +192,7 @@ jobs:
           profile: minimal
           override: true
       - run: cargo install cross
-      - run: cross test --release --target ${{ matrix.target }} --features armv8
-      - run: cross test --release --target ${{ matrix.target }} --features armv8,force-soft
-      - run: cross test --release --target ${{ matrix.target }} --features armv8,std
-      - run: cross test --release --target ${{ matrix.target }} --features armv8,zeroize
-      - run: cross test --release --target ${{ matrix.target }} --all-features
+      - run: cross test --target ${{ matrix.target }} --release
+      - run: cross test --target ${{ matrix.target }} --release --features std
+      - run: cross test --target ${{ matrix.target }} --release --features zeroize
+      - run: cross test --target ${{ matrix.target }} --release --all-features

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -27,5 +27,3 @@ hex-literal = "0.3"
 
 [features]
 std = ["polyval/std"]
-armv8 = ["polyval/armv8"]
-force-soft = ["polyval/force-soft"]

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -24,5 +24,4 @@ cpufeatures = "0.2"
 hex-literal = "0.3"
 
 [features]
-force-soft = []
 std = ["universal-hash/std"]

--- a/poly1305/src/backend.rs
+++ b/poly1305/src/backend.rs
@@ -2,13 +2,13 @@
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft")
+    not(poly1305_force_soft)
 ))]
 pub(crate) mod avx2;
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft")
+    not(poly1305_force_soft)
 ))]
 pub(crate) mod autodetect;
 

--- a/poly1305/src/lib.rs
+++ b/poly1305/src/lib.rs
@@ -64,7 +64,7 @@ mod backend;
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft"),
+    not(poly1305_force_soft),
     target_feature = "avx2", // Fuzz tests bypass AVX2 autodetection code
     any(fuzzing, test)
 ))]
@@ -72,13 +72,13 @@ mod fuzz;
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft")
+    not(poly1305_force_soft)
 ))]
 use crate::backend::autodetect::State;
 
 #[cfg(not(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft")
+    not(poly1305_force_soft)
 )))]
 use crate::backend::soft::State;
 
@@ -164,7 +164,7 @@ opaque_debug::implement!(Poly1305);
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
-    not(feature = "force-soft"),
+    not(poly1305_force_soft),
     target_feature = "avx2", // Fuzz tests bypass AVX2 autodetection code
     any(fuzzing, test)
 ))]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -28,9 +28,7 @@ cpufeatures = "0.2"
 hex-literal = "0.3"
 
 [features]
-std        = ["universal-hash/std"]
-armv8      = [] # Enable nightly-only ARMv8 intrinsics support
-force-soft = [] # Disable support for hardware intrinsics
+std = ["universal-hash/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -7,13 +7,13 @@ mod soft;
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_arch = "aarch64", feature = "armv8", not(feature = "force-soft")))] {
+    if #[cfg(all(target_arch = "aarch64", polyval_armv8, not(polyval_force_soft)))] {
         mod autodetect;
         mod pmull;
         pub use crate::backend::autodetect::Polyval;
     } else if #[cfg(all(
         any(target_arch = "x86_64", target_arch = "x86"),
-        not(feature = "force-soft")
+        not(polyval_force_soft)
     ))] {
         mod autodetect;
         mod clmul;

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -75,7 +75,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(all(feature = "armv8", target_arch = "aarch64"), feature(stdsimd))]
+#![cfg_attr(all(polyval_armv8, target_arch = "aarch64"), feature(stdsimd))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"


### PR DESCRIPTION
Following the changes in e.g. the `aes` crate, this replaces cargo features for this functionality with attributes which can be provided in the toplevel build configuration as arguments to rustc:

- poly1305: `poly1305_force_soft`
- polyval: `polyval_armv8`, `polyval_force_soft`

This follows a similar naming scheme in the `aes` crate: `aes_force_soft`

It would probably make sense to consolidate these so we have the samenames across crates like `aes` and `polyval` so it could be activated with a single attribute, e.g. `rustcrypto_armv8`/`rustcrypto_force_soft`

However, for consistency this uses a similar scheme to what is already released in the `aes` crate.