### PR TITLE
Bump `universal-hash` to v0.5.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddf84cbf3ff76dc1546cd2d7fb8e98f3fecb4de9a4ef68243bc76c14244f557"
+checksum = "9411a446a0bdf07b404c359da8fe71919391662c857a13f6f19e8bd53ad01750"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 opaque-debug = "0.3"
-universal-hash = { version = "=0.5.0-pre.1", default-features = false }
+universal-hash = { version = "=0.5.0-pre.2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/poly1305/src/backend/avx2.rs
+++ b/poly1305/src/backend/avx2.rs
@@ -198,6 +198,12 @@ impl UhfBackend for State {
     }
 
     fn blocks_needed_to_align(&self) -> usize {
-        self.cached_blocks.len() - self.num_cached_blocks
+        if self.num_cached_blocks == 0 {
+            // There are no cached blocks; fast path is available.
+            0
+        } else {
+            // There are cached blocks; report how many more we need.
+            self.cached_blocks.len() - self.num_cached_blocks
+        }
     }
 }

--- a/poly1305/src/backend/avx2.rs
+++ b/poly1305/src/backend/avx2.rs
@@ -196,4 +196,8 @@ impl UhfBackend for State {
             }
         }
     }
+
+    fn blocks_needed_to_align(&self) -> usize {
+        self.cached_blocks.len() - self.num_cached_blocks
+    }
 }

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 [dependencies]
 cfg-if = "1"
 opaque-debug = "0.3"
-universal-hash = { version = "=0.5.0-pre.1", default-features = false }
+universal-hash = { version = "=0.5.0-pre.2", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]


### PR DESCRIPTION
This adds `UhfBackend::blocks_needed_to_align` and impls it for the AVX2 backend of Poly1305.