### PR TITLE
Cut `-pre.2` releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 dependencies = [
  "hex-literal",
  "opaque-debug",
@@ -67,7 +67,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0-pre.1"
+version = "0.8.0-pre.2"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.5.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "=0.6.0-pre.1", path = "../polyval" }
+polyval = { version = "=0.6.0-pre.2", path = "../polyval" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.8.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
These prereleases use `universal-hash` v0.5.0-pre.2:

- `ghash` v0.5.0-pre.2
- `poly13095` v0.8.0-pre.2
- `polyval` v0.6.0-pre.2