### PR TITLE
Bump `universal-hash` to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9411a446a0bdf07b404c359da8fe71919391662c857a13f6f19e8bd53ad01750"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 opaque-debug = "0.3"
-universal-hash = { version = "=0.5.0-pre.2", default-features = false }
+universal-hash = { version = "0.5", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 [dependencies]
 cfg-if = "1"
 opaque-debug = "0.3"
-universal-hash = { version = "=0.5.0-pre.2", default-features = false }
+universal-hash = { version = "0.5", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/1061