### PR TITLE
poly1305 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0-pre.2"
+version = "0.8.0"
 dependencies = [
  "cpufeatures",
  "hex-literal",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0 (2022-07-31)
 ### Changed
 - Relax `zeroize` constraints ([#147])
 - Upgrade to Rust 2021 edition ([#147])
+- Use stable `aarch64_target_feature` ([#154])
+- Bump `universal-hash` to v0.5 ([#155], [#162])
+- Replace `armv8`/`force-soft` features with `cfg` attributes ([#159])
+
+### Removed
+- `armv8`/`force-soft` features ([#159])
 
 [#147]: https://github.com/RustCrypto/universal-hashes/pull/147
+[#154]: https://github.com/RustCrypto/universal-hashes/pull/154
+[#155]: https://github.com/RustCrypto/universal-hashes/pull/155
+[#159]: https://github.com/RustCrypto/universal-hashes/pull/159
+[#162]: https://github.com/RustCrypto/universal-hashes/pull/162
 
 ## 0.7.2 (2021-08-27)
 ### Changed

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.8.0-pre.2"
+version = "0.8.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Changed
- Relax `zeroize` constraints ([#147])
- Upgrade to Rust 2021 edition ([#147])
- Use stable `aarch64_target_feature` ([#154])
- Bump `universal-hash` to v0.5 ([#155], [#162])
- Replace `armv8`/`force-soft` features with `cfg` attributes ([#159])

### Removed
- `armv8`/`force-soft` features ([#159])

[#147]: https://github.com/RustCrypto/universal-hashes/pull/147
[#154]: https://github.com/RustCrypto/universal-hashes/pull/154
[#155]: https://github.com/RustCrypto/universal-hashes/pull/155
[#159]: https://github.com/RustCrypto/universal-hashes/pull/159
[#162]: https://github.com/RustCrypto/universal-hashes/pull/162