### PR TITLE
polyval v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0-pre.2"
+version = "0.6.0"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 
 [dependencies]
 opaque-debug = "0.3"
-polyval = { version = "=0.6.0-pre.2", path = "../polyval" }
+polyval = { version = "0.6", path = "../polyval" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,14 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.6.0 (2022-07-31)
+### Added
+- Impl `Reset` ([#157])
+
 ### Changed
 - Remove `sse4.1` from CPU feature requirements for PCLMUL backend ([#143])
 - Relax `zeroize` constraints ([#147])
 - Upgrade to Rust 2021 edition ([#147])
+- Use stable `aarch64_target_feature` ([#154])
+- Replace `armv8`/`force-soft` features with `cfg` attributes ([#159])
+- Bump `universal-hash` to v0.5 ([#155], [#162])
 
 [#143]: https://github.com/RustCrypto/universal-hashes/pull/143
 [#147]: https://github.com/RustCrypto/universal-hashes/pull/147
+[#154]: https://github.com/RustCrypto/universal-hashes/pull/154
+[#155]: https://github.com/RustCrypto/universal-hashes/pull/155
+[#157]: https://github.com/RustCrypto/universal-hashes/pull/157
+[#159]: https://github.com/RustCrypto/universal-hashes/pull/159
+[#162]: https://github.com/RustCrypto/universal-hashes/pull/162
 
 ## 0.5.3 (2021-08-27)
 ### Changed

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.6.0-pre.2"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- Impl `Reset` ([#157])

### Changed
- Remove `sse4.1` from CPU feature requirements for PCLMUL backend ([#143])
- Relax `zeroize` constraints ([#147])
- Upgrade to Rust 2021 edition ([#147])
- Use stable `aarch64_target_feature` ([#154])
- Replace `armv8`/`force-soft` features with `cfg` attributes ([#159])
- Bump `universal-hash` to v0.5 ([#155], [#162])

[#143]: https://github.com/RustCrypto/universal-hashes/pull/143
[#147]: https://github.com/RustCrypto/universal-hashes/pull/147
[#154]: https://github.com/RustCrypto/universal-hashes/pull/154
[#155]: https://github.com/RustCrypto/universal-hashes/pull/155
[#157]: https://github.com/RustCrypto/universal-hashes/pull/157
[#159]: https://github.com/RustCrypto/universal-hashes/pull/159
[#162]: https://github.com/RustCrypto/universal-hashes/pull/162