### PR TITLE
ghash v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 dependencies = [
  "hex-literal",
  "opaque-debug",

--- a/ghash/CHANGELOG.md
+++ b/ghash/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.0 (2022-07-31)
 ### Changed
 - Relax `zeroize` constraints ([#147])
 - Upgrade to Rust 2021 edition ([#147])
+- Bump `polyval` to v0.6.0 ([#164])
 
 [#147]: https://github.com/RustCrypto/universal-hashes/pull/147
+[#164]: https://github.com/RustCrypto/universal-hashes/pull/164
 
 ## 0.4.4 (2021-08-27)
 ### Changed

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Relax `zeroize` constraints ([#147])
- Upgrade to Rust 2021 edition ([#147])
- Replace `armv8`/`force-soft` features with `cfg` attributes ([#159])
- Bump `polyval` to v0.6.0 ([#164])

[#147]: https://github.com/RustCrypto/universal-hashes/pull/147
[#159]: https://github.com/RustCrypto/universal-hashes/pull/159
[#164]: https://github.com/RustCrypto/universal-hashes/pull/164