### PR TITLE
polyval v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2023-06-16)
+### Added
+- Support for `polyval_armv8` on Rust 1.61+ ([#179])
+
+[#179]: https://github.com/RustCrypto/universal-hashes/pull/179
+
 ## 0.6.0 (2022-07-31)
 ### Added
 - Impl `Reset` ([#157])

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/polyval/LICENSE-MIT
+++ b/polyval/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 RustCrypto Developers
+Copyright (c) 2019-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/polyval/README.md
+++ b/polyval/README.md
@@ -2,9 +2,9 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
-[![Build Status][build-image]][build-link]
 
 [POLYVAL][1] ([RFC 8452][2]) is a [universal hash function][3] which operates
 over GF(2^128) and can be used for constructing a
@@ -47,14 +47,14 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/polyval.svg
+[crate-image]: https://buildstats.info/crate/polyval
 [crate-link]: https://crates.io/crates/polyval
 [docs-image]: https://docs.rs/polyval/badge.svg
 [docs-link]: https://docs.rs/polyval/
-[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/RustCrypto/universal-hashes/workflows/polyval/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/universal-hashes/actions?query=workflow%3Apolyval
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 
 [//]: # (footnotes)
 


### PR DESCRIPTION
### Added
- Support for `polyval_armv8` on Rust 1.61+ ([#179])

[#179]: https://github.com/RustCrypto/universal-hashes/pull/179