### PR TITLE
Exclude unnecessary fuzz files

### DIFF
--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 rust-version = "1.65"
 edition = "2021"
+exclude = ["/fuzz/"]
 
 [dependencies]
 opaque-debug = "0.3"


### PR DESCRIPTION
The crate file contains a few unnecessary files in the `fuzz/` directory — I would expect people to run fuzz tests from a Git working copy.