### PR TITLE
poly1305+polyval: add `lints.rust.unexpected_cfgs`

### DIFF
--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -25,3 +25,7 @@ hex-literal = "0.3"
 
 [features]
 std = ["universal-hash/std"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(fuzzing)", "cfg(poly1305_force_soft)"]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -30,6 +30,10 @@ hex-literal = "0.3"
 [features]
 std = ["universal-hash/std"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(polyval_armv8)", "cfg(polyval_force_soft)"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Fixes warnings on Rust 1.80