### PR TITLE
Cargo.lock: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -57,18 +57,18 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c2311a0adecbffff284aabcf1249b1485193b16e685f9ef171b1ba82979cff"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "opaque-debug"
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "typenum"
@@ -138,6 +138,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/poly1305/tests/lib.rs
+++ b/poly1305/tests/lib.rs
@@ -1,7 +1,7 @@
 use hex_literal::hex;
 use poly1305::{
     universal_hash::{KeyInit, UniversalHash},
-    Block, Poly1305, BLOCK_SIZE, KEY_SIZE,
+    Block, Poly1305, KEY_SIZE,
 };
 use std::iter::repeat;
 
@@ -43,7 +43,7 @@ fn donna_self_test1() {
     let expected = hex!("03000000000000000000000000000000");
 
     let mut poly = Poly1305::new(key.as_ref());
-    poly.update(&[Block::clone_from_slice(msg.as_ref())]);
+    poly.update(&[msg.into()]);
     assert_eq!(&expected[..], poly.finalize().as_slice());
 }
 
@@ -75,10 +75,7 @@ fn test_tls_vectors() {
 
     let mut poly = Poly1305::new(key.as_ref());
 
-    let blocks = msg
-        .chunks(BLOCK_SIZE)
-        .map(Block::clone_from_slice)
-        .collect::<Vec<_>>();
+    let blocks = Block::slice_as_chunks(&msg).0;
     poly.update(&blocks);
 
     assert_eq!(&expected[..], poly.finalize().as_slice());

--- a/polyval/src/mulx.rs
+++ b/polyval/src/mulx.rs
@@ -46,7 +46,7 @@ mod tests {
 
         for vector in MULX_TEST_VECTORS {
             r = mulx(&r);
-            assert_eq!(&r, Block::from_slice(vector));
+            assert_eq!(&r, vector);
         }
     }
 


### PR DESCRIPTION
Updates the following dependencies:

    $ cargo update
    Updating crates.io index
     Locking 5 packages to latest compatible versions
    Updating getrandom v0.2.12 -> v0.2.15
    Updating hybrid-array v0.2.0-rc.7 -> v0.2.0-rc.9
    Updating libc v0.2.149 -> v0.2.155
    Updating subtle v2.5.0 -> v2.6.1

Also: fix hybrid-array deprecation warnings