### PR TITLE
define poly const in polyval pmull

### DIFF
--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -21,6 +21,12 @@ use universal_hash::{
 
 use crate::{Block, Key, Tag};
 
+/// Montgomery reduction polynomial `p(x)` defined as:
+/// \[
+///     p(x) = x^{127} + x^{126} + x^{121} + x^{63} + x^{62} + x^{57}
+/// \]
+const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
+
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[derive(Clone)]
 pub struct Polyval {
@@ -163,7 +169,7 @@ unsafe fn mont_reduce(x23: uint8x16_t, x01: uint8x16_t) -> uint8x16_t {
     //    [C1:C0] = B0 • poly
     //    [D1:D0] = [B0 ⊕ C1 : B1 ⊕ C0]
     // Output: [D1 ⊕ X3 : D0 ⊕ X2]
-    let poly = vreinterpretq_u8_p128(1 << 127 | 1 << 126 | 1 << 121 | 1 << 63 | 1 << 62 | 1 << 57);
+    let poly = vreinterpretq_u8_p128(POLY);
     let a = pmull(x01, poly);
     let b = veorq_u8(x01, vextq_u8(a, a, 8));
     let c = pmull2(b, poly);

--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -21,10 +21,7 @@ use universal_hash::{
 
 use crate::{Block, Key, Tag};
 
-/// Montgomery reduction polynomial `p(x)` defined as:
-/// \[
-///     p(x) = x^{127} + x^{126} + x^{121} + x^{63} + x^{62} + x^{57}
-/// \]
+/// Montgomery reduction polynomial
 const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).


### PR DESCRIPTION
`poly` can be defined as a constant at a file level and it doesn't need to be recalculated inside the function as it is an hardcoded value.