### PR TITLE
polyval+ghash: large performance improvements via better instruction-level parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,6 @@ name = "ghash"
 version = "0.6.0-rc.0"
 dependencies = [
  "hex-literal",
- "opaque-debug",
  "polyval",
  "zeroize",
 ]

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-opaque-debug = "0.3"
 polyval = { version = "0.7.0-rc.0", path = "../polyval" }
 
 # optional dependencies

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -33,11 +33,11 @@ pub use polyval::universal_hash;
 
 use polyval::PolyvalGeneric;
 use universal_hash::{
-    array::ArraySize,
     KeyInit, UhfBackend, UhfClosure, UniversalHash,
+    array::ArraySize,
     consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
-    typenum::{U, ToUInt, Const},
+    typenum::{Const, ToUInt, U},
 };
 
 #[cfg(feature = "zeroize")]
@@ -99,7 +99,7 @@ impl<const N: usize> GHashGeneric<N> {
     }
 }
 
-impl<const N:usize> KeyInit for GHashGeneric<N> {
+impl<const N: usize> KeyInit for GHashGeneric<N> {
     /// Initialize GHASH with the given `H` field element
     #[inline]
     fn new(h: &Key) -> Self {
@@ -125,11 +125,11 @@ impl<B: UhfBackend> UhfBackend for GHashGenericBackend<'_, B> {
     }
 }
 
-impl<const N:usize> BlockSizeUser for GHashGeneric<N> {
+impl<const N: usize> BlockSizeUser for GHashGeneric<N> {
     type BlockSize = U16;
 }
 
-impl<const N:usize> UniversalHash for GHashGeneric<N>
+impl<const N: usize> UniversalHash for GHashGeneric<N>
 where
     U<N>: ArraySize,
     Const<N>: ToUInt,

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -159,4 +159,11 @@ where
     }
 }
 
-opaque_debug::implement!(GHashGeneric);
+impl<const N: usize> core::fmt::Debug for GHashGeneric<N> {
+    fn fmt(
+        &self,
+        f: &mut core::fmt::Formatter,
+    ) -> Result<(), core::fmt::Error> {
+        write!(f, "GHashGeneric<{}> {{ ... }}", N)
+    }
+}

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -160,10 +160,7 @@ where
 }
 
 impl<const N: usize> core::fmt::Debug for GHashGeneric<N> {
-    fn fmt(
-        &self,
-        f: &mut core::fmt::Formatter,
-    ) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         write!(f, "GHashGeneric<{}> {{ ... }}", N)
     }
 }

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -31,11 +31,13 @@
 
 pub use polyval::universal_hash;
 
-use polyval::Polyval;
+use polyval::PolyvalGeneric;
 use universal_hash::{
+    array::ArraySize,
     KeyInit, UhfBackend, UhfClosure, UniversalHash,
     consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
+    typenum::{U, ToUInt, Const},
 };
 
 #[cfg(feature = "zeroize")]
@@ -54,14 +56,27 @@ pub type Tag = universal_hash::Block<GHash>;
 ///
 /// GHASH is a universal hash function used for message authentication in
 /// the AES-GCM authenticated encryption cipher.
-#[derive(Clone)]
-pub struct GHash(Polyval);
+pub type GHash = GHashGeneric<8>;
 
-impl KeySizeUser for GHash {
+/// **GHASH**: universal hash over GF(2^128) used by AES-GCM.
+///
+/// GHASH is a universal hash function used for message authentication in
+/// the AES-GCM authenticated encryption cipher.
+///
+/// Paramaterized on a constant that determines how many
+/// blocks to process at once: higher numbers use more memory,
+/// and require more time to re-key, but process data significantly
+/// faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
+#[derive(Clone)]
+pub struct GHashGeneric<const N: usize = 8>(PolyvalGeneric<N>);
+
+impl<const N: usize> KeySizeUser for GHashGeneric<N> {
     type KeySize = U16;
 }
 
-impl GHash {
+impl<const N: usize> GHashGeneric<N> {
     /// Initialize GHASH with the given `H` field element and initial block
     #[inline]
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
@@ -75,7 +90,7 @@ impl GHash {
         h.zeroize();
 
         #[allow(clippy::let_and_return)]
-        let result = GHash(Polyval::new_with_init_block(&h_polyval, init_block));
+        let result = GHashGeneric(PolyvalGeneric::new_with_init_block(&h_polyval, init_block));
 
         #[cfg(feature = "zeroize")]
         h_polyval.zeroize();
@@ -84,7 +99,7 @@ impl GHash {
     }
 }
 
-impl KeyInit for GHash {
+impl<const N:usize> KeyInit for GHashGeneric<N> {
     /// Initialize GHASH with the given `H` field element
     #[inline]
     fn new(h: &Key) -> Self {
@@ -92,17 +107,17 @@ impl KeyInit for GHash {
     }
 }
 
-struct GHashBackend<'b, B: UhfBackend>(&'b mut B);
+struct GHashGenericBackend<'b, B: UhfBackend>(&'b mut B);
 
-impl<B: UhfBackend> BlockSizeUser for GHashBackend<'_, B> {
+impl<B: UhfBackend> BlockSizeUser for GHashGenericBackend<'_, B> {
     type BlockSize = B::BlockSize;
 }
 
-impl<B: UhfBackend> ParBlocksSizeUser for GHashBackend<'_, B> {
+impl<B: UhfBackend> ParBlocksSizeUser for GHashGenericBackend<'_, B> {
     type ParBlocksSize = B::ParBlocksSize;
 }
 
-impl<B: UhfBackend> UhfBackend for GHashBackend<'_, B> {
+impl<B: UhfBackend> UhfBackend for GHashGenericBackend<'_, B> {
     fn proc_block(&mut self, x: &universal_hash::Block<B>) {
         let mut x = x.clone();
         x.reverse();
@@ -110,25 +125,29 @@ impl<B: UhfBackend> UhfBackend for GHashBackend<'_, B> {
     }
 }
 
-impl BlockSizeUser for GHash {
+impl<const N:usize> BlockSizeUser for GHashGeneric<N> {
     type BlockSize = U16;
 }
 
-impl UniversalHash for GHash {
+impl<const N:usize> UniversalHash for GHashGeneric<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
     fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>) {
-        struct GHashClosure<C: UhfClosure>(C);
+        struct GHashGenericClosure<C: UhfClosure>(C);
 
-        impl<C: UhfClosure> BlockSizeUser for GHashClosure<C> {
+        impl<C: UhfClosure> BlockSizeUser for GHashGenericClosure<C> {
             type BlockSize = C::BlockSize;
         }
 
-        impl<C: UhfClosure> UhfClosure for GHashClosure<C> {
+        impl<C: UhfClosure> UhfClosure for GHashGenericClosure<C> {
             fn call<B: UhfBackend<BlockSize = Self::BlockSize>>(self, backend: &mut B) {
-                self.0.call(&mut GHashBackend(backend));
+                self.0.call(&mut GHashGenericBackend(backend));
             }
         }
 
-        self.0.update_with_backend(GHashClosure(f));
+        self.0.update_with_backend(GHashGenericClosure(f));
     }
 
     /// Get GHASH output
@@ -140,4 +159,4 @@ impl UniversalHash for GHash {
     }
 }
 
-opaque_debug::implement!(GHash);
+opaque_debug::implement!(GHashGeneric);

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -17,6 +17,7 @@ cfg_if! {
     ))] {
         mod autodetect;
         mod clmul;
+        mod common;
         pub use crate::backend::autodetect::Polyval;
     } else {
         pub use crate::backend::soft::Polyval;

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -10,6 +10,7 @@ cfg_if! {
     if #[cfg(all(target_arch = "aarch64", not(polyval_force_soft)))] {
         mod autodetect;
         mod pmull;
+        mod common;
         pub use crate::backend::autodetect::Polyval;
     } else if #[cfg(all(
         any(target_arch = "x86_64", target_arch = "x86"),

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -11,7 +11,7 @@ cfg_if! {
         mod autodetect;
         mod pmull;
         mod common;
-        pub use crate::backend::autodetect::Polyval;
+        pub use crate::backend::autodetect::Polyval as PolyvalGeneric;
     } else if #[cfg(all(
         any(target_arch = "x86_64", target_arch = "x86"),
         not(polyval_force_soft)
@@ -19,8 +19,13 @@ cfg_if! {
         mod autodetect;
         mod clmul;
         mod common;
-        pub use crate::backend::autodetect::Polyval;
+        pub use crate::backend::autodetect::Polyval as PolyvalGeneric;
     } else {
-        pub use crate::backend::soft::Polyval;
+        pub use crate::backend::soft::Polyval as PolyvalGeneric;
     }
 }
+
+/// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+//
+// We have to define a type alias here, or existing code will break.
+pub type Polyval = PolyvalGeneric<8>;

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -38,7 +38,7 @@ pub struct Polyval<const N: usize = 8> {
 
 union Inner<const N: usize> {
     intrinsics: ManuallyDrop<intrinsics::Polyval<N>>,
-    soft: ManuallyDrop<soft::Polyval>,
+    soft: ManuallyDrop<soft::Polyval<N>>,
 }
 
 impl<const N: usize> KeySizeUser for Polyval<N> {

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -5,8 +5,10 @@ use crate::{Key, Tag, backend::soft};
 use core::mem::ManuallyDrop;
 use universal_hash::{
     KeyInit, Reset, UhfClosure, UniversalHash,
+    array::ArraySize,
     consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser},
+    typenum::{Const, ToUInt, U},
 };
 
 #[cfg(target_arch = "aarch64")]
@@ -22,21 +24,28 @@ cpufeatures::new!(mul_intrinsics, "aes"); // `aes` implies PMULL
 cpufeatures::new!(mul_intrinsics, "pclmulqdq");
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
-pub struct Polyval {
-    inner: Inner,
+///
+/// Paramaterized on a constant that determines how many
+/// blocks to process at once: higher numbers use more memory,
+/// and require more time to re-key, but process data significantly
+/// faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
+pub struct Polyval<const N: usize = 8> {
+    inner: Inner<N>,
     token: mul_intrinsics::InitToken,
 }
 
-union Inner {
-    intrinsics: ManuallyDrop<intrinsics::Polyval>,
+union Inner<const N: usize> {
+    intrinsics: ManuallyDrop<intrinsics::Polyval<N>>,
     soft: ManuallyDrop<soft::Polyval>,
 }
 
-impl KeySizeUser for Polyval {
+impl<const N: usize> KeySizeUser for Polyval<N> {
     type KeySize = U16;
 }
 
-impl Polyval {
+impl<const N: usize> Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element and initial block
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
         let (token, has_intrinsics) = mul_intrinsics::init_get();
@@ -57,18 +66,22 @@ impl Polyval {
     }
 }
 
-impl KeyInit for Polyval {
+impl<const N: usize> KeyInit for Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element
     fn new(h: &Key) -> Self {
         Self::new_with_init_block(h, 0)
     }
 }
 
-impl BlockSizeUser for Polyval {
+impl<const N: usize> BlockSizeUser for Polyval<N> {
     type BlockSize = U16;
 }
 
-impl UniversalHash for Polyval {
+impl<const N: usize> UniversalHash for Polyval<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
     fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>) {
         unsafe {
             if self.token.get() {
@@ -91,7 +104,7 @@ impl UniversalHash for Polyval {
     }
 }
 
-impl Clone for Polyval {
+impl<const N: usize> Clone for Polyval<N> {
     fn clone(&self) -> Self {
         let inner = if self.token.get() {
             Inner {
@@ -110,7 +123,7 @@ impl Clone for Polyval {
     }
 }
 
-impl Reset for Polyval {
+impl<const N: usize> Reset for Polyval<N> {
     fn reset(&mut self) {
         if self.token.get() {
             unsafe { (*self.inner.intrinsics).reset() }

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -161,7 +161,7 @@ impl<const N: usize> Drop for Polyval<N> {
 
 /// # Safety
 ///
-/// The SSE2 and pclmulqdq target features must be enavled.
+/// The SSE2 and pclmulqdq target features must be enabled.
 #[inline]
 #[target_feature(enable = "sse2,pclmulqdq")]
 #[allow(unused_unsafe)]

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -83,9 +83,9 @@ where
     Const<N>: ToUInt,
 {
     fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
-	unsafe {
-	    self.mul_par_blocks(blocks);
-	}
+        unsafe {
+            self.mul_par_blocks(blocks);
+        }
     }
 
     fn proc_block(&mut self, x: &Block) {
@@ -106,7 +106,6 @@ impl<const N: usize> Polyval<N>
 where
     U<N>: ArraySize,
     Const<N>: ToUInt,
-
 {
     #[inline]
     #[target_feature(enable = "pclmulqdq")]

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -1,5 +1,8 @@
 //! Intel `CLMUL`-accelerated implementation for modern x86/x86_64 CPUs
 //! (i.e. Intel Sandy Bridge-compatible or newer)
+//!
+//! Based on implementation by Eric Lagergren
+//! at <https://github.com/ericlagergren/polyval-rs/>.
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -13,6 +16,7 @@ use universal_hash::{
 };
 
 use crate::{Block, Key, Tag};
+use core::ptr;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[derive(Clone)]
@@ -63,7 +67,7 @@ impl UhfBackend for Polyval {
 }
 
 impl Polyval {
-    /// Get GHASH output
+    /// Get Polyval output
     pub(crate) fn finalize(self) -> Tag {
         unsafe { core::mem::transmute(self.y) }
     }
@@ -74,75 +78,8 @@ impl Polyval {
     #[target_feature(enable = "pclmulqdq")]
     #[allow(unsafe_op_in_unsafe_fn)]
     unsafe fn mul(&mut self, x: &Block) {
-        #[inline(always)]
-        unsafe fn xor4(e1: __m128i, e2: __m128i, e3: __m128i, e4: __m128i) -> __m128i {
-            _mm_xor_si128(_mm_xor_si128(e1, e2), _mm_xor_si128(e3, e4))
-        }
-
-        #[inline(always)]
-        unsafe fn xor5(e1: __m128i, e2: __m128i, e3: __m128i, e4: __m128i, e5: __m128i) -> __m128i {
-            _mm_xor_si128(
-                e1,
-                _mm_xor_si128(_mm_xor_si128(e2, e3), _mm_xor_si128(e4, e5)),
-            )
-        }
-
-        let h = self.h;
-
-        // `_mm_loadu_si128` performs an unaligned load
-        #[allow(clippy::cast_ptr_alignment)]
-        let x = _mm_loadu_si128(x.as_ptr() as *const __m128i);
-        let y = _mm_xor_si128(self.y, x);
-
-        let h0 = h;
-        let h1 = _mm_shuffle_epi32(h, 0x0E);
-        let h2 = _mm_xor_si128(h0, h1);
-        let y0 = y;
-
-        // Multiply values partitioned to 64-bit parts
-        let y1 = _mm_shuffle_epi32(y, 0x0E);
-        let y2 = _mm_xor_si128(y0, y1);
-        let t0 = _mm_clmulepi64_si128(y0, h0, 0x00);
-        let t1 = _mm_clmulepi64_si128(y, h, 0x11);
-        let t2 = _mm_clmulepi64_si128(y2, h2, 0x00);
-        let t2 = _mm_xor_si128(t2, _mm_xor_si128(t0, t1));
-        let v0 = t0;
-        let v1 = _mm_xor_si128(_mm_shuffle_epi32(t0, 0x0E), t2);
-        let v2 = _mm_xor_si128(t1, _mm_shuffle_epi32(t2, 0x0E));
-        let v3 = _mm_shuffle_epi32(t1, 0x0E);
-
-        // Polynomial reduction
-        let v2 = xor5(
-            v2,
-            v0,
-            _mm_srli_epi64(v0, 1),
-            _mm_srli_epi64(v0, 2),
-            _mm_srli_epi64(v0, 7),
-        );
-
-        let v1 = xor4(
-            v1,
-            _mm_slli_epi64(v0, 63),
-            _mm_slli_epi64(v0, 62),
-            _mm_slli_epi64(v0, 57),
-        );
-
-        let v3 = xor5(
-            v3,
-            v1,
-            _mm_srli_epi64(v1, 1),
-            _mm_srli_epi64(v1, 2),
-            _mm_srli_epi64(v1, 7),
-        );
-
-        let v2 = xor4(
-            v2,
-            _mm_slli_epi64(v1, 63),
-            _mm_slli_epi64(v1, 62),
-            _mm_slli_epi64(v1, 57),
-        );
-
-        self.y = _mm_unpacklo_epi64(v2, v3);
+        let x = _mm_loadu_si128(x.as_ptr().cast());
+        self.y = polymul(_mm_xor_si128(self.y, x), self.h);
     }
 }
 
@@ -161,4 +98,137 @@ impl Drop for Polyval {
         self.h.zeroize();
         self.y.zeroize();
     }
+}
+
+/// # Safety
+///
+/// The SSE2 and pclmulqdq target features must be enavled.
+#[inline]
+#[target_feature(enable = "sse2,pclmulqdq")]
+#[allow(unused_unsafe)]
+#[allow(clippy::undocumented_unsafe_blocks, reason = "Too many unsafe blocks.")]
+unsafe fn polymul(x: __m128i, y: __m128i) -> __m128i {
+    let (h, m, l) = unsafe { karatsuba1(x, y) };
+    let (h, l) = unsafe { karatsuba2(h, m, l) };
+    unsafe {
+        mont_reduce(h, l) // d
+    }
+}
+
+/// Karatsuba decomposition for `x*y`.
+#[inline]
+#[target_feature(enable = "sse2,pclmulqdq")]
+#[allow(unused_unsafe)]
+#[allow(clippy::undocumented_unsafe_blocks, reason = "Too many unsafe blocks.")]
+unsafe fn karatsuba1(x: __m128i, y: __m128i) -> (__m128i, __m128i, __m128i) {
+    // First Karatsuba step: decompose x and y.
+    //
+    // (x1*y0 + x0*y1) = (x1+x0) * (y1+x0) + (x1*y1) + (x0*y0)
+    //        M                                 H         L
+    //
+    // m = x.hi^x.lo * y.hi^y.lo
+    let m = unsafe {
+        pmull(
+            _mm_xor_si128(x, _mm_shuffle_epi32(x, 0xee)),
+            _mm_xor_si128(y, _mm_shuffle_epi32(y, 0xee)),
+        )
+    };
+    let h = unsafe { pmull2(y, x) }; // h = x.hi * y.hi
+    let l = unsafe { pmull(y, x) }; // l = x.lo * y.lo
+    (h, m, l)
+}
+
+/// Karatsuba combine.
+#[inline]
+#[target_feature(enable = "sse2,pclmulqdq")]
+#[allow(unused_unsafe)]
+#[allow(clippy::undocumented_unsafe_blocks, reason = "Too many unsafe blocks.")]
+unsafe fn karatsuba2(h: __m128i, m: __m128i, l: __m128i) -> (__m128i, __m128i) {
+    // Second Karatsuba step: combine into a 2n-bit product.
+    //
+    // m0 ^= l0 ^ h0 // = m0^(l0^h0)
+    // m1 ^= l1 ^ h1 // = m1^(l1^h1)
+    // l1 ^= m0      // = l1^(m0^l0^h0)
+    // h0 ^= l0 ^ m1 // = h0^(l0^m1^l1^h1)
+    // h1 ^= l1      // = h1^(l1^m0^l0^h0)
+    let t = unsafe {
+        //   {m0, m1} ^ {l1, h0}
+        // = {m0^l1, m1^h0}
+        let t0 = {
+            _mm_xor_si128(
+                m,
+                _mm_castps_si128(_mm_shuffle_ps(
+                    _mm_castsi128_ps(l),
+                    _mm_castsi128_ps(h),
+                    0x4e,
+                )),
+            )
+        };
+
+        //   {h0, h1} ^ {l0, l1}
+        // = {h0^l0, h1^l1}
+        let t1 = _mm_xor_si128(h, l);
+
+        //   {m0^l1, m1^h0} ^ {h0^l0, h1^l1}
+        // = {m0^l1^h0^l0, m1^h0^h1^l1}
+        _mm_xor_si128(t0, t1)
+    };
+
+    // {m0^l1^h0^l0, l0}
+    let x01 = unsafe { _mm_unpacklo_epi64(l, t) };
+
+    // {h1, m1^h0^h1^l1}
+    let x23 = unsafe { _mm_castps_si128(_mm_movehl_ps(_mm_castsi128_ps(h), _mm_castsi128_ps(t))) };
+
+    (x23, x01)
+}
+
+/// # Safety
+///
+/// The SSE2 and pclmulqdq target features must be enavled.
+#[inline]
+#[target_feature(enable = "sse2,pclmulqdq")]
+#[allow(unused_unsafe)]
+#[allow(clippy::undocumented_unsafe_blocks, reason = "Too many unsafe blocks.")]
+unsafe fn mont_reduce(x23: __m128i, x01: __m128i) -> __m128i {
+    // Perform the Montgomery reduction over the 256-bit X.
+    //    [A1:A0] = X0 • poly
+    //    [B1:B0] = [X0 ⊕ A1 : X1 ⊕ A0]
+    //    [C1:C0] = B0 • poly
+    //    [D1:D0] = [B0 ⊕ C1 : B1 ⊕ C0]
+    // Output: [D1 ⊕ X3 : D0 ⊕ X2]
+    static POLY: u128 = 1 << 127 | 1 << 126 | 1 << 121 | 1 << 63 | 1 << 62 | 1 << 57;
+    let poly = unsafe { _mm_loadu_si128(ptr::addr_of!(POLY).cast()) };
+    let a = unsafe { pmull(x01, poly) };
+    let b = unsafe { _mm_xor_si128(x01, _mm_shuffle_epi32(a, 0x4e)) };
+    let c = unsafe { pmull2(b, poly) };
+    unsafe { _mm_xor_si128(x23, _mm_xor_si128(c, b)) }
+}
+
+/// Multiplies the low bits in `a` and `b`.
+///
+/// # Safety
+///
+/// The SSE2 and pclmulqdq target features must be enabled.
+#[inline]
+#[allow(unused_unsafe)]
+#[target_feature(enable = "sse2,pclmulqdq")]
+unsafe fn pmull(a: __m128i, b: __m128i) -> __m128i {
+    // SAFETY: This requires the `sse2` and `pclmulqdq` features
+    // which we have.
+    unsafe { _mm_clmulepi64_si128(a, b, 0x00) }
+}
+
+/// Multiplies the high bits in `a` and `b`.
+///
+/// # Safety
+///
+/// The SSE2 and pclmulqdq target features must be enavled.
+#[inline]
+#[allow(unused_unsafe)]
+#[target_feature(enable = "sse2,pclmulqdq")]
+unsafe fn pmull2(a: __m128i, b: __m128i) -> __m128i {
+    // SAFETY: This requires the `sse2` and `pclmulqdq` features
+    // which we have.
+    unsafe { _mm_clmulepi64_si128(a, b, 0x11) }
 }

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -12,7 +12,7 @@ use core::arch::x86_64::*;
 use universal_hash::{
     KeyInit, ParBlocks, Reset, UhfBackend,
     array::ArraySize,
-    consts::{U16},
+    consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     typenum::{Const, ToUInt, U},
 };
@@ -23,6 +23,9 @@ use core::ptr;
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[derive(Clone)]
 pub struct Polyval<const N: usize = 8> {
+    /// Powers of H in descending order.
+    ///
+    /// (H^N, H^(N-1)...H)
     h: [__m128i; N],
     y: __m128i,
 }
@@ -40,8 +43,8 @@ impl<const N: usize> Polyval<N> {
             let h = _mm_loadu_si128(h.as_ptr() as *const __m128i);
 
             Self {
-		// introducing a closure here because polymul is unsafe.
-                h: common::powers_of_h(h, |a, b| { polymul(a, b) }),
+                // introducing a closure here because polymul is unsafe.
+                h: common::powers_of_h(h, |a, b| polymul(a, b)),
                 y: _mm_loadu_si128(&init_block.to_be_bytes()[..] as *const _ as *const __m128i),
             }
         }

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -21,6 +21,13 @@ use crate::{Block, Key, Tag, backend::common};
 use core::ptr;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+///
+/// Paramaterized on a constant that determines how many
+/// blocks to process at once: higher numbers use more memory,
+/// and require more time to re-key, but process data significantly
+/// faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
 #[derive(Clone)]
 pub struct Polyval<const N: usize = 8> {
     /// Powers of H in descending order.

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -83,6 +83,34 @@ where
     Const<N>: ToUInt,
 {
     fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
+	unsafe {
+	    self.mul_par_blocks(blocks);
+	}
+    }
+
+    fn proc_block(&mut self, x: &Block) {
+        unsafe {
+            self.mul(x);
+        }
+    }
+}
+
+impl<const N: usize> Polyval<N> {
+    /// Get Polyval output
+    pub(crate) fn finalize(self) -> Tag {
+        unsafe { core::mem::transmute(self.y) }
+    }
+}
+
+impl<const N: usize> Polyval<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+
+{
+    #[inline]
+    #[target_feature(enable = "pclmulqdq")]
+    unsafe fn mul_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
         unsafe {
             let mut h = _mm_setzero_si128();
             let mut m = _mm_setzero_si128();
@@ -106,21 +134,6 @@ where
         }
     }
 
-    fn proc_block(&mut self, x: &Block) {
-        unsafe {
-            self.mul(x);
-        }
-    }
-}
-
-impl<const N: usize> Polyval<N> {
-    /// Get Polyval output
-    pub(crate) fn finalize(self) -> Tag {
-        unsafe { core::mem::transmute(self.y) }
-    }
-}
-
-impl<const N: usize> Polyval<N> {
     #[inline]
     #[target_feature(enable = "pclmulqdq")]
     #[allow(unsafe_op_in_unsafe_fn)]

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -244,7 +244,7 @@ unsafe fn mont_reduce(x23: __m128i, x01: __m128i) -> __m128i {
     //    [C1:C0] = B0 • poly
     //    [D1:D0] = [B0 ⊕ C1 : B1 ⊕ C0]
     // Output: [D1 ⊕ X3 : D0 ⊕ X2]
-    static POLY: u128 = 1 << 127 | 1 << 126 | 1 << 121 | 1 << 63 | 1 << 62 | 1 << 57;
+    static POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
     let poly = unsafe { _mm_loadu_si128(ptr::addr_of!(POLY).cast()) };
     let a = unsafe { pmull(x01, poly) };
     let b = unsafe { _mm_xor_si128(x01, _mm_shuffle_epi32(a, 0x4e)) };

--- a/polyval/src/backend/common.rs
+++ b/polyval/src/backend/common.rs
@@ -1,0 +1,25 @@
+//! Common implementation utilities shared among backends.
+
+/// Compute the first N powers of h, in reverse order.
+#[inline]
+pub(super) fn powers_of_h<T, MUL, const N: usize>(h: T, mul: MUL) -> [T; N]
+where
+    T: Clone + Copy,
+    MUL: Fn(T, T) -> T,
+{
+    // (We could use MaybeUninit here, but the compiler should be smart enough to
+    // see that everything is replaced.)
+    let mut pow: [T; N] = [h; N];
+
+    // TODO: We could _maybe_ improve the pipelining here by using more
+    // square operations, but it might not help.
+    let mut prev = h;
+    for (i, v) in pow.iter_mut().rev().enumerate() {
+        *v = h;
+        if i > 0 {
+            *v = mul(*v, prev);
+        }
+        prev = *v
+    }
+    pow
+}

--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -7,6 +7,9 @@
 //! Based on code from ARM, and by Johannes Schneiders, Skip Hovsmith and
 //! Barry O'Rourke for the mbedTLS project.
 //!
+//! Incorporates performance improvements from Eric Lagergren
+//! at <https://github.com/ericlagergren/polyval-rs/>.
+//!
 //! For more information about PMULL, see:
 //! - <https://developer.arm.com/documentation/100069/0608/A64-SIMD-Vector-Instructions/PMULL--PMULL2--vector->
 //! - <https://eprint.iacr.org/2015/688.pdf>
@@ -15,63 +18,103 @@
 use core::{arch::aarch64::*, mem};
 
 use universal_hash::{
-    KeyInit, Reset, UhfBackend,
-    consts::{U1, U16},
+    KeyInit, ParBlocks, Reset, UhfBackend,
+    array::ArraySize,
+    consts::U16,
     crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
+    typenum::{Const, ToUInt, U},
 };
 
-use crate::{Block, Key, Tag};
+use crate::{Block, Key, Tag, backend::common};
 
 /// Montgomery reduction polynomial
 const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 #[derive(Clone)]
-pub struct Polyval {
-    h: uint8x16_t,
+pub struct Polyval<const N: usize = 8> {
+    /// Powers of H in descending order.
+    ///
+    /// (H^N, H^(N-1)...H)
+    h: [uint8x16_t; N],
     y: uint8x16_t,
 }
 
-impl KeySizeUser for Polyval {
+impl<const N: usize> KeySizeUser for Polyval<N> {
     type KeySize = U16;
 }
 
-impl Polyval {
+impl<const N: usize> Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element and initial block
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
         unsafe {
+            let h = vld1q_u8(h.as_ptr());
             Self {
-                h: vld1q_u8(h.as_ptr()),
+                // introducing a closure here because polymul is unsafe.
+                h: common::powers_of_h(h, |a, b| polymul(a, b)),
                 y: vld1q_u8(init_block.to_be_bytes()[..].as_ptr()),
             }
         }
     }
 }
 
-impl KeyInit for Polyval {
+impl<const N: usize> KeyInit for Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element
     fn new(h: &Key) -> Self {
         Self::new_with_init_block(h, 0)
     }
 }
 
-impl BlockSizeUser for Polyval {
+impl<const N: usize> BlockSizeUser for Polyval<N> {
     type BlockSize = U16;
 }
 
-impl ParBlocksSizeUser for Polyval {
-    type ParBlocksSize = U1;
+impl<const N: usize> ParBlocksSizeUser for Polyval<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
+    type ParBlocksSize = U<N>;
 }
 
-impl UhfBackend for Polyval {
+impl<const N: usize> UhfBackend for Polyval<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
+    fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
+        unsafe {
+            let mut h = vdupq_n_u8(0);
+            let mut m = vdupq_n_u8(0);
+            let mut l = vdupq_n_u8(0);
+
+            // Note: Manually unrolling this loop did not help in benchmarks.
+            for i in (0..N).rev() {
+                let mut x = vld1q_u8(blocks[i].as_ptr());
+                if i == 0 {
+                    x = veorq_u8(x, self.y);
+                }
+                let y = self.h[i];
+                let (hh, mm, ll) = karatsuba1(x, y);
+                h = veorq_u8(h, hh);
+                m = veorq_u8(m, mm);
+                l = veorq_u8(l, ll);
+            }
+
+            let (h, l) = karatsuba2(h, m, l);
+            self.y = mont_reduce(h, l);
+        }
+    }
+
     fn proc_block(&mut self, x: &Block) {
         unsafe {
-            self.mul(x);
+            let y = veorq_u8(self.y, vld1q_u8(x.as_ptr()));
+            self.y = polymul(y, self.h[N - 1]);
         }
     }
 }
 
-impl Reset for Polyval {
+impl<const N: usize> Reset for Polyval<N> {
     fn reset(&mut self) {
         unsafe {
             self.y = vdupq_n_u8(0);
@@ -79,22 +122,21 @@ impl Reset for Polyval {
     }
 }
 
-impl Polyval {
+impl<const N: usize> Polyval<N> {
     /// Get POLYVAL output.
     pub(crate) fn finalize(self) -> Tag {
         unsafe { mem::transmute(self.y) }
     }
+}
 
-    /// POLYVAL carryless multiplication.
-    // TODO(tarcieri): investigate ordering optimizations and fusions e.g.`fuse-crypto-eor`
-    #[inline]
-    #[target_feature(enable = "neon")]
-    unsafe fn mul(&mut self, x: &Block) {
-        let y = veorq_u8(self.y, vld1q_u8(x.as_ptr()));
-        let (h, m, l) = karatsuba1(self.h, y);
-        let (h, l) = karatsuba2(h, m, l);
-        self.y = mont_reduce(h, l);
-    }
+/// Multipy "y" by "h" and return the result.
+// TODO(tarcieri): investigate ordering optimizations and fusions e.g.`fuse-crypto-eor`
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn polymul(y: uint8x16_t, h: uint8x16_t) -> uint8x16_t {
+    let (h, m, l) = karatsuba1(h, y);
+    let (h, l) = karatsuba2(h, m, l);
+    mont_reduce(h, l)
 }
 
 /// Karatsuba decomposition for `x*y`.
@@ -195,7 +237,7 @@ unsafe fn pmull2(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 }
 // TODO(tarcieri): zeroize support
 // #[cfg(feature = "zeroize")]
-// impl Drop for Polyval {
+// impl Drop for Polyval<N> {
 //     fn drop(&mut self) {
 //         use zeroize::Zeroize;
 //         self.h.zeroize();

--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -31,6 +31,13 @@ use crate::{Block, Key, Tag, backend::common};
 const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+///
+/// Paramaterized on a constant that determines how many
+/// blocks to process at once: higher numbers use more memory,
+/// and require more time to re-key, but process data significantly
+/// faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
 #[derive(Clone)]
 pub struct Polyval<const N: usize = 8> {
     /// Powers of H in descending order.

--- a/polyval/src/backend/soft32.rs
+++ b/polyval/src/backend/soft32.rs
@@ -65,7 +65,7 @@ impl<const N: usize> KeySizeUser for Polyval<N> {
     type KeySize = U16;
 }
 
-impl<const N: usize> Polyval {
+impl<const N: usize> Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element and initial block
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
         Self {

--- a/polyval/src/backend/soft32.rs
+++ b/polyval/src/backend/soft32.rs
@@ -24,6 +24,11 @@
 //!
 //! In other words, if we bit-reverse (over 32 bits) the operands, then we
 //! bit-reverse (over 64 bits) the result.
+//!
+//! Note that this implementation doesn't use its generic argument,
+//! since (experimentally) it gets no performance benefit from doing so.
+//! `N` is present only so that we can provide a `GenericPolyval` that
+//! is always generic.
 
 use crate::{Block, Key, Tag};
 use core::{
@@ -40,8 +45,15 @@ use universal_hash::{
 use zeroize::Zeroize;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+///
+/// Paramaterized on a constant that determines how many
+/// blocks to process at once: higher numbers use more memory,
+/// and require more time to re-key, but process data significantly
+/// faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
 #[derive(Clone)]
-pub struct Polyval {
+pub struct Polyval<const N: usize> {
     /// GF(2^128) field element input blocks are multiplied by
     h: U32x4,
 
@@ -49,11 +61,11 @@ pub struct Polyval {
     s: U32x4,
 }
 
-impl KeySizeUser for Polyval {
+impl<const N: usize> KeySizeUser for Polyval<N> {
     type KeySize = U16;
 }
 
-impl Polyval {
+impl<const N: usize> Polyval {
     /// Initialize POLYVAL with the given `H` field element and initial block
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
         Self {
@@ -63,29 +75,29 @@ impl Polyval {
     }
 }
 
-impl KeyInit for Polyval {
+impl<const N: usize> KeyInit for Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element
     fn new(h: &Key) -> Self {
         Self::new_with_init_block(h, 0)
     }
 }
 
-impl BlockSizeUser for Polyval {
+impl<const N: usize> BlockSizeUser for Polyval<N> {
     type BlockSize = U16;
 }
 
-impl ParBlocksSizeUser for Polyval {
+impl<const N: usize> ParBlocksSizeUser for Polyval<N> {
     type ParBlocksSize = U1;
 }
 
-impl UhfBackend for Polyval {
+impl<const N: usize> UhfBackend for Polyval<N> {
     fn proc_block(&mut self, x: &Block) {
         let x = U32x4::from(x);
         self.s = (self.s + x) * self.h;
     }
 }
 
-impl UniversalHash for Polyval {
+impl<const N: usize> UniversalHash for Polyval<N> {
     fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>) {
         f.call(self);
     }
@@ -105,14 +117,14 @@ impl UniversalHash for Polyval {
     }
 }
 
-impl Reset for Polyval {
+impl<const N: usize> Reset for Polyval<N> {
     fn reset(&mut self) {
         self.s = U32x4::default();
     }
 }
 
 #[cfg(feature = "zeroize")]
-impl Drop for Polyval {
+impl<const N: usize> Drop for Polyval<N> {
     fn drop(&mut self) {
         self.h.zeroize();
         self.s.zeroize();

--- a/polyval/src/backend/soft32.rs
+++ b/polyval/src/backend/soft32.rs
@@ -53,7 +53,7 @@ use zeroize::Zeroize;
 ///
 /// (This constant is not used when acceleration is not enabled.)
 #[derive(Clone)]
-pub struct Polyval<const N: usize> {
+pub struct Polyval<const N: usize = 1> {
     /// GF(2^128) field element input blocks are multiplied by
     h: U32x4,
 

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -84,7 +84,14 @@ mod mulx;
 pub use crate::{backend::Polyval, backend::PolyvalGeneric, mulx::mulx};
 pub use universal_hash;
 
-opaque_debug::implement!(PolyvalGeneric);
+impl<const N: usize> core::fmt::Debug for PolyvalGeneric<N> {
+    fn fmt(
+        &self,
+        f: &mut core::fmt::Formatter,
+    ) -> Result<(), core::fmt::Error> {
+        write!(f, "PolyvalGeneric<{}> {{ ... }}", N)
+    }
+}
 
 /// Size of a POLYVAL block in bytes
 pub const BLOCK_SIZE: usize = 16;

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -81,10 +81,10 @@
 mod backend;
 mod mulx;
 
-pub use crate::{backend::Polyval, mulx::mulx};
+pub use crate::{backend::Polyval, backend::PolyvalGeneric, mulx::mulx};
 pub use universal_hash;
 
-opaque_debug::implement!(Polyval);
+opaque_debug::implement!(PolyvalGeneric);
 
 /// Size of a POLYVAL block in bytes
 pub const BLOCK_SIZE: usize = 16;

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -85,10 +85,7 @@ pub use crate::{backend::Polyval, backend::PolyvalGeneric, mulx::mulx};
 pub use universal_hash;
 
 impl<const N: usize> core::fmt::Debug for PolyvalGeneric<N> {
-    fn fmt(
-        &self,
-        f: &mut core::fmt::Formatter,
-    ) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         write!(f, "PolyvalGeneric<{}> {{ ... }}", N)
     }
 }

--- a/polyval/tests/lib.rs
+++ b/polyval/tests/lib.rs
@@ -24,3 +24,25 @@ fn polyval_test_vector() {
     let result = poly.finalize();
     assert_eq!(&POLYVAL_RESULT[..], result.as_slice());
 }
+
+// A longer test case, to ensure that long-input optimizations
+// behave correctly.
+
+#[test]
+fn polyval_longer_test() {
+    let inp = (1..=4096).map(|n| (n * 47) as u8).collect::<Vec<_>>();
+
+    // Try computing polyval all at once.
+    let mut poly = Polyval::new(&H.into());
+    poly.update_padded(&inp);
+    let result1 = poly.finalize_reset();
+
+    // Try computing polyval one block at a time.
+    for block in inp.chunks(BLOCK_SIZE) {
+        poly.update(&[block.try_into().unwrap()]);
+    }
+    let result2 = poly.finalize();
+
+    // Make sure the results are the same.
+    assert_eq!(result1, result2);
+}

--- a/polyval/tests/lib.rs
+++ b/polyval/tests/lib.rs
@@ -1,7 +1,7 @@
 use hex_literal::hex;
 use polyval::{
-    BLOCK_SIZE, Polyval,
-    universal_hash::{KeyInit, UniversalHash},
+    BLOCK_SIZE, Polyval, PolyvalGeneric,
+    universal_hash::{KeyInit, Reset, UniversalHash, crypto_common::KeySizeUser, typenum::U16},
 };
 
 //
@@ -28,12 +28,14 @@ fn polyval_test_vector() {
 // A longer test case, to ensure that long-input optimizations
 // behave correctly.
 
-#[test]
-fn polyval_longer_test() {
+fn longer_test<Imp>()
+where
+    Imp: UniversalHash + KeyInit + Reset + Clone + KeySizeUser<KeySize = U16>,
+{
     let inp = (1..=4096).map(|n| (n * 47) as u8).collect::<Vec<_>>();
 
     // Try computing polyval all at once.
-    let mut poly = Polyval::new(&H.into());
+    let mut poly = Imp::new(&H.into());
     poly.update_padded(&inp);
     let result1 = poly.finalize_reset();
 
@@ -45,4 +47,21 @@ fn polyval_longer_test() {
 
     // Make sure the results are the same.
     assert_eq!(result1, result2);
+}
+
+#[test]
+fn longer_test_x1() {
+    longer_test::<PolyvalGeneric<1>>();
+}
+#[test]
+fn longer_test_x2() {
+    longer_test::<PolyvalGeneric<2>>();
+}
+#[test]
+fn longer_test_x4() {
+    longer_test::<PolyvalGeneric<4>>();
+}
+#[test]
+fn longer_test_x8() {
+    longer_test::<PolyvalGeneric<8>>();
 }


### PR DESCRIPTION
This MR adapts code from @ericlagergren with permission (see #225) to speed up polyval and ghash.

I expect there are still some performance gains to be had, but this is already fairly well improved: I'm seeing ~~4.3x~~ 7.5x improvement for large inputs on my Alder Lake x86_64 CPU, and 10x improvement on my Apple M1 ARM CPU.

Because this pipelining is not always appropriate (notably, when you know that you will only be handling small inputs), I've also imitated polyval-rs by making the number of blocks to parallelize a generic parameter.

I experimented with manually unrolling the loops here, but I didn't see a performance gain.
