### PR TITLE
polyval: switch from `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -32,4 +32,3 @@ check-cfg = ["cfg(polyval_force_soft)"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",


### PR DESCRIPTION
See RustCrypto/traits#2028