### PR TITLE
ci: update all upstream dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
 - package-ecosystem: cargo
+  versioning-strategy: lockfile-only
   directory: "/"
+  allow:
+    - dependency-type: "all"
+  groups:
+    all-deps:
+      patterns:
+        - "*"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
This change automates Cargo.lock updates.