### PR TITLE
Cut rc.3 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 dependencies = [
  "hex-literal",
  "polyval",
@@ -58,7 +58,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -16,7 +16,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-polyval = { version = "0.7.0-rc.2", path = "../polyval" }
+polyval = { version = "0.7.0-rc.3", path = "../polyval" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
Releases the following:
- `ghash` v0.6.0-rc.3
- `poly1305` v0.9.0-rc.3
- `polyval` v0.7.0-rc.3