### PR TITLE
polyval: replace `polyval_force_soft` with `polyval_backend="soft"`

### DIFF
--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -28,7 +28,7 @@ hex-literal = "1"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ["cfg(polyval_force_soft)"]
+check-cfg = ['cfg(polyval_backend, values("soft"))']
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -5,14 +5,14 @@ mod soft;
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(all(target_arch = "aarch64", not(polyval_force_soft)))] {
+    if #[cfg(all(target_arch = "aarch64", not(polyval_backend = "soft")))] {
         mod autodetect;
         mod pmull;
         mod common;
         pub use crate::backend::autodetect::Polyval as PolyvalGeneric;
     } else if #[cfg(all(
         any(target_arch = "x86_64", target_arch = "x86"),
-        not(polyval_force_soft)
+        not(polyval_backend = "soft")
     ))] {
         mod autodetect;
         mod clmul;


### PR DESCRIPTION
This is more extensible if we want to add other customizable overrides in the future.

e.g. I think it'd be pretty easy to add a NEON backend but it would be cool if I could test it by doing:

    RUSTFLAGS='--cfg polyval_backend="neon"' cargo test

...rather than having to hack up the selection logic in `backend.rs` by hand.