### PR TITLE
polyval: use `cpubits` crate for `soft` backend selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "cfg-if"
-version = "1.0.4"
+name = "cpubits"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+checksum = "251aaca52dbc19119279d9364222e188ffdf48006791040bfd002617ab0ebc41"
 
 [[package]]
 name = "cpufeatures"
@@ -70,7 +70,7 @@ dependencies = [
 name = "polyval"
 version = "0.7.0-rc.3"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "cpufeatures",
  "hex-literal",
  "universal-hash",

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-cfg-if = "1"
+cpubits = "0.1.0-rc.1"
 universal-hash = { version = "0.6.0-rc.4", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -2,7 +2,7 @@
 
 mod soft;
 
-use cfg_if::cfg_if;
+use cpubits::cfg_if;
 
 cfg_if! {
     if #[cfg(all(target_arch = "aarch64", not(polyval_backend = "soft")))] {

--- a/polyval/src/backend/soft.rs
+++ b/polyval/src/backend/soft.rs
@@ -1,26 +1,16 @@
 //! Portable software implementation. Provides implementations for low power 32-bit devices as well
 //! as a 64-bit implementation.
 
-// Use 64-bit backend on 64-bit targets, ARMv7, and WASM.
-// Fall back to 32-bit backend on others
-// TODO(tarcieri): use `cpubits` crate when available?
-#[cfg_attr(
-    not(any(
-        target_pointer_width = "64",
-        all(target_arch = "arm", target_feature = "v7"),
-        target_family = "wasm"
-    )),
-    path = "soft/soft32.rs"
-)]
-#[cfg_attr(
-    any(
-        target_pointer_width = "64",
-        all(target_arch = "arm", target_feature = "v7"),
-        target_family = "wasm"
-    ),
-    path = "soft/soft64.rs"
-)]
-mod soft_impl;
+cpubits::cpubits! {
+    16 | 32 => {
+        #[path = "soft/soft32.rs"]
+        mod soft_impl;
+    }
+    64 => {
+        #[path = "soft/soft64.rs"]
+        mod soft_impl;
+    }
+}
 
 use crate::{Block, Key, Tag};
 use soft_impl::*;


### PR DESCRIPTION
We provide both 32-bit and 64-bit pure Rust implementations of POLYVAL in `soft32.rs` and `soft64.rs`.

This commit addresses a TODO to use the `cpubits` crate to select between them.

It contains equivalent 64-bit overrides to what we already had, but also provides a common place to add additional such overrides for other targets in the future.