### PR TITLE
polyval: expand clippy lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.0
+          toolchain: 1.93.0
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -26,9 +26,48 @@ cpufeatures = "0.2"
 [dev-dependencies]
 hex-literal = "1"
 
+[lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(polyval_backend, values("soft"))']
+
+[lints.clippy]
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+#undocumented_unsafe_blocks = "warn" TODO
+unnecessary_safety_comment = "warn"
+unwrap_in_result = "warn"
+unwrap_used = "warn"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polyval/benches/polyval.rs
+++ b/polyval/benches/polyval.rs
@@ -1,3 +1,5 @@
+//! `polyval` crate benchmarks.
+
 #![feature(test)]
 
 extern crate test;

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -47,6 +47,7 @@ impl<const N: usize> KeySizeUser for Polyval<N> {
 
 impl<const N: usize> Polyval<N> {
     /// Initialize POLYVAL with the given `H` field element and initial block
+    #[must_use]
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
         let (token, has_intrinsics) = mul_intrinsics::init_get();
 
@@ -85,9 +86,9 @@ where
     fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>) {
         unsafe {
             if self.token.get() {
-                f.call(&mut *self.inner.intrinsics)
+                f.call(&mut *self.inner.intrinsics);
             } else {
-                f.call(&mut *self.inner.soft)
+                f.call(&mut *self.inner.soft);
             }
         }
     }

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -47,12 +47,12 @@ impl<const N: usize> Polyval<N> {
         unsafe {
             // `_mm_loadu_si128` performs an unaligned load
             #[allow(clippy::cast_ptr_alignment)]
-            let h = _mm_loadu_si128(h.as_ptr() as *const __m128i);
+            let h = _mm_loadu_si128(h.as_ptr().cast::<__m128i>());
 
             Self {
                 // introducing a closure here because polymul is unsafe.
                 h: common::powers_of_h(h, |a, b| polymul(a, b)),
-                y: _mm_loadu_si128(&init_block.to_be_bytes()[..] as *const _ as *const __m128i),
+                y: _mm_loadu_si128(ptr::from_ref(&init_block.to_be_bytes()[..]).cast::<__m128i>()),
             }
         }
     }

--- a/polyval/src/backend/common.rs
+++ b/polyval/src/backend/common.rs
@@ -19,7 +19,7 @@ where
         if i > 0 {
             *v = mul(*v, prev);
         }
-        prev = *v
+        prev = *v;
     }
     pow
 }

--- a/polyval/src/backend/soft/soft32.rs
+++ b/polyval/src/backend/soft/soft32.rs
@@ -35,6 +35,7 @@ use core::{
     num::Wrapping,
     ops::{Add, Mul},
 };
+use universal_hash::crypto_common::array::{Array, sizes::U4};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -47,11 +48,15 @@ impl FieldElement {
     /// Decode field element from little endian bytestring representation.
     #[inline]
     pub(super) fn from_le_bytes(bytes: &Block) -> FieldElement {
+        // TODO(tarcieri): use `[T]::as_chunks` when MSRV is 1.88
+        let (chunks, remainder) = Array::<u8, U4>::slice_as_chunks(bytes);
+        debug_assert!(remainder.is_empty());
+
         FieldElement(
-            u32::from_le_bytes(bytes[..4].try_into().unwrap()),
-            u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-            u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-            u32::from_le_bytes(bytes[12..].try_into().unwrap()),
+            u32::from_le_bytes(chunks[0].into()),
+            u32::from_le_bytes(chunks[1].into()),
+            u32::from_le_bytes(chunks[2].into()),
+            u32::from_le_bytes(chunks[3].into()),
         )
     }
 

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -5,7 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![warn(missing_docs)]
 
 mod backend;
 mod mulx;

--- a/polyval/src/mulx.rs
+++ b/polyval/src/mulx.rs
@@ -8,6 +8,7 @@ use crate::Block;
 /// This is useful for implementing GHASH in terms of POLYVAL.
 ///
 /// [1]: https://tools.ietf.org/html/rfc8452#appendix-A
+#[must_use]
 pub fn mulx(block: &Block) -> Block {
     let mut v = u128::from_le_bytes((*block).into());
     let v_hi = v >> 127;

--- a/polyval/tests/lib.rs
+++ b/polyval/tests/lib.rs
@@ -1,3 +1,5 @@
+//! POLYVAL integration tests.
+
 use hex_literal::hex;
 use polyval::{
     BLOCK_SIZE, Polyval, PolyvalGeneric,


### PR DESCRIPTION
Applies the same lints we recently applied to https://github.com/RustCrypto/utils

Somewhat annoyingly, because this crate configures `lints.rust.unexpected_cfgs`, I wasn't able to use `lints.workspace = true`, nor was I able to figure out a way to source just the clippy lints from the workspace, so this just sets them at the level of the crate.