### PR TITLE
polyval: refactor soft backend

### DIFF
--- a/polyval/src/backend/soft/soft64.rs
+++ b/polyval/src/backend/soft/soft64.rs
@@ -46,6 +46,51 @@ impl FieldElement {
         hi.copy_from_slice(&self.1.to_le_bytes());
         block
     }
+
+    /// Compute the unreduced 256-bit carryless product of two 128-bit field elements.
+    ///
+    /// Uses a Karatsuba decomposition in which the 128x128 multiplication is reduced to three 64x64
+    /// multiplications together with a bit-reversal trick to efficiently recover the high half.
+    #[inline]
+    fn karatsuba(self, rhs: FieldElement) -> (u64, u64, u64, u64) {
+        // Karatsuba input decomposition for H
+        let h0 = self.0;
+        let h1 = self.1;
+        let h0r = h0.reverse_bits();
+        let h1r = h1.reverse_bits();
+        let h2 = h0 ^ h1;
+        let h2r = h0r ^ h1r;
+
+        // Karatsuba input decomposition for Y
+        let y0 = rhs.0;
+        let y1 = rhs.1;
+        let y0r = y0.reverse_bits();
+        let y1r = y1.reverse_bits();
+        let y2 = y0 ^ y1;
+        let y2r = y0r ^ y1r;
+
+        // Perform carryless multiplications
+        let z0 = bmul64(y0, h0);
+        let z1 = bmul64(y1, h1);
+        let mut z2 = bmul64(y2, h2);
+        let mut z0h = bmul64(y0r, h0r);
+        let mut z1h = bmul64(y1r, h1r);
+        let mut z2h = bmul64(y2r, h2r);
+
+        // Karatsuba recombination
+        z2 ^= z0 ^ z1;
+        z2h ^= z0h ^ z1h;
+        z0h = z0h.reverse_bits() >> 1;
+        z1h = z1h.reverse_bits() >> 1;
+        z2h = z2h.reverse_bits() >> 1;
+
+        // Assemble the final 256-bit product as 64x4
+        let v0 = z0;
+        let v1 = z0h ^ z2;
+        let v2 = z1 ^ z2h;
+        let v3 = z1h;
+        (v0, v1, v2, v3)
+    }
 }
 
 impl From<u128> for FieldElement {
@@ -63,67 +108,43 @@ impl Add for FieldElement {
     }
 }
 
-#[allow(clippy::suspicious_arithmetic_impl)]
+/// Computes carryless POLYVAL multiplication over GF(2^128) in constant time.
+///
+/// Method described at: <https://www.bearssl.org/constanttime.html#ghash-for-gcm>
+///
+/// POLYVAL multiplication is effectively the little endian equivalent of
+/// GHASH multiplication, aside from one small detail described here:
+///
+/// <https://crypto.stackexchange.com/questions/66448/how-does-bearssls-gcm-modular-reduction-work/66462#66462>
+///
+/// > The product of two bit-reversed 128-bit polynomials yields the
+/// > bit-reversed result over 255 bits, not 256. The BearSSL code ends up
+/// > with a 256-bit result in zw[], and that value is shifted by one bit,
+/// > because of that reversed convention issue. Thus, the code must
+/// > include a shifting step to put it back where it should
+///
+/// This shift is unnecessary for POLYVAL and has been removed.
 impl Mul for FieldElement {
     type Output = Self;
 
-    /// Computes carryless POLYVAL multiplication over GF(2^128) in constant time.
-    ///
-    /// Method described at:
-    /// <https://www.bearssl.org/constanttime.html#ghash-for-gcm>
-    ///
-    /// POLYVAL multiplication is effectively the little endian equivalent of
-    /// GHASH multiplication, aside from one small detail described here:
-    ///
-    /// <https://crypto.stackexchange.com/questions/66448/how-does-bearssls-gcm-modular-reduction-work/66462#66462>
-    ///
-    /// > The product of two bit-reversed 128-bit polynomials yields the
-    /// > bit-reversed result over 255 bits, not 256. The BearSSL code ends up
-    /// > with a 256-bit result in zw[], and that value is shifted by one bit,
-    /// > because of that reversed convention issue. Thus, the code must
-    /// > include a shifting step to put it back where it should
-    ///
-    /// This shift is unnecessary for POLYVAL and has been removed.
     fn mul(self, rhs: Self) -> Self {
-        let h0 = self.0;
-        let h1 = self.1;
-        let h0r = h0.reverse_bits();
-        let h1r = h1.reverse_bits();
-        let h2 = h0 ^ h1;
-        let h2r = h0r ^ h1r;
-
-        let y0 = rhs.0;
-        let y1 = rhs.1;
-        let y0r = y0.reverse_bits();
-        let y1r = y1.reverse_bits();
-        let y2 = y0 ^ y1;
-        let y2r = y0r ^ y1r;
-        let z0 = bmul64(y0, h0);
-        let z1 = bmul64(y1, h1);
-
-        let mut z2 = bmul64(y2, h2);
-        let mut z0h = bmul64(y0r, h0r);
-        let mut z1h = bmul64(y1r, h1r);
-        let mut z2h = bmul64(y2r, h2r);
-
-        z2 ^= z0 ^ z1;
-        z2h ^= z0h ^ z1h;
-        z0h = z0h.reverse_bits() >> 1;
-        z1h = z1h.reverse_bits() >> 1;
-        z2h = z2h.reverse_bits() >> 1;
-
-        let v0 = z0;
-        let mut v1 = z0h ^ z2;
-        let mut v2 = z1 ^ z2h;
-        let mut v3 = z1h;
-
-        v2 ^= v0 ^ (v0 >> 1) ^ (v0 >> 2) ^ (v0 >> 7);
-        v1 ^= (v0 << 63) ^ (v0 << 62) ^ (v0 << 57);
-        v3 ^= v1 ^ (v1 >> 1) ^ (v1 >> 2) ^ (v1 >> 7);
-        v2 ^= (v1 << 63) ^ (v1 << 62) ^ (v1 << 57);
-
-        FieldElement(v2, v3)
+        let (v0, v1, v2, v3) = self.karatsuba(rhs);
+        mont_reduce(v0, v1, v2, v3)
     }
+}
+
+/// Reduce the 256-bit carryless product of Karatsuba modulo the POLYVAL polynomial.
+///
+/// This performs constant-time folding using shifts and XORs corresponding to the irreducible
+/// polynomial `x^128 + x^127 + x^126 + x^121 + 1`. This is closely related to GHASH reduction but
+/// the polynomial's bit order is reversed in POLYVAL.
+#[inline]
+fn mont_reduce(v0: u64, mut v1: u64, mut v2: u64, mut v3: u64) -> FieldElement {
+    v2 ^= v0 ^ (v0 >> 1) ^ (v0 >> 2) ^ (v0 >> 7);
+    v1 ^= (v0 << 63) ^ (v0 << 62) ^ (v0 << 57);
+    v3 ^= v1 ^ (v1 >> 1) ^ (v1 >> 2) ^ (v1 >> 7);
+    v2 ^= (v1 << 63) ^ (v1 << 62) ^ (v1 << 57);
+    FieldElement(v2, v3)
 }
 
 #[cfg(feature = "zeroize")]
@@ -134,30 +155,30 @@ impl Zeroize for FieldElement {
     }
 }
 
-/// Multiplication in GF(2)[X], truncated to the low 64-bits, with “holes”
-/// (sequences of zeroes) to avoid carry spilling.
+/// Multiplication in GF(2)[X], truncated to the low 64-bits, with "holes" (sequences of zeroes) to
+/// avoid carry spilling.
 ///
-/// When carries do occur, they wind up in a "hole" and are subsequently masked
-/// out of the result.
+/// When carries do occur, they wind up in a "hole" and are subsequently masked out of the result.
 fn bmul64(x: u64, y: u64) -> u64 {
-    let x0 = Wrapping(x & 0x1111_1111_1111_1111);
-    let x1 = Wrapping(x & 0x2222_2222_2222_2222);
-    let x2 = Wrapping(x & 0x4444_4444_4444_4444);
-    let x3 = Wrapping(x & 0x8888_8888_8888_8888);
-    let y0 = Wrapping(y & 0x1111_1111_1111_1111);
-    let y1 = Wrapping(y & 0x2222_2222_2222_2222);
-    let y2 = Wrapping(y & 0x4444_4444_4444_4444);
-    let y3 = Wrapping(y & 0x8888_8888_8888_8888);
+    const M0: u64 = 0x1111_1111_1111_1111;
+    const M1: u64 = 0x2222_2222_2222_2222;
+    const M2: u64 = 0x4444_4444_4444_4444;
+    const M3: u64 = 0x8888_8888_8888_8888;
 
-    let mut z0 = ((x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1)).0;
-    let mut z1 = ((x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2)).0;
-    let mut z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3)).0;
-    let mut z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0)).0;
+    let x0 = Wrapping(x & M0);
+    let x1 = Wrapping(x & M1);
+    let x2 = Wrapping(x & M2);
+    let x3 = Wrapping(x & M3);
 
-    z0 &= 0x1111_1111_1111_1111;
-    z1 &= 0x2222_2222_2222_2222;
-    z2 &= 0x4444_4444_4444_4444;
-    z3 &= 0x8888_8888_8888_8888;
+    let y0 = Wrapping(y & M0);
+    let y1 = Wrapping(y & M1);
+    let y2 = Wrapping(y & M2);
+    let y3 = Wrapping(y & M3);
 
-    z0 | z1 | z2 | z3
+    let z0 = (x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1);
+    let z1 = (x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2);
+    let z2 = (x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3);
+    let z3 = (x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0);
+
+    (z0.0 & M0) | (z1.0 & M1) | (z2.0 & M2) | (z3.0 & M3)
 }


### PR DESCRIPTION
This is mostly cosmetic changes that refactor and clean up the portable pure Rust implementations of POLYVAL we provide.

It extracts `karatsuba` and `mont_reduce` functions similar to the other backends (though those decompose Karatsuba into two steps, which is hard to do here due to the bit reversal trick), and adds comments explaining the steps.

The carryless multiplication functions `bmul32` and `bmul64` are cleaned up a bit by using some constants for the masks instead of repeating literals.