### PR TITLE
Bump `universal-hash` to v0.6.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca141d401f08b91a03a23c3cdd32064da6a4a30b1714d7c3f2f62299644d11f"
+checksum = "82084f2919885ea910502c74f0a362827aaad3d28d142ca97448bfb39c7e271a"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -12,8 +12,8 @@ use polyval::PolyvalGeneric;
 use universal_hash::{
     KeyInit, UhfBackend, UhfClosure, UniversalHash,
     array::ArraySize,
+    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     consts::U16,
-    crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     typenum::{Const, ToUInt, U},
 };
 

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-universal-hash = { version = "0.6.0-rc.7", default-features = false }
+universal-hash = { version = "0.6.0-rc.8", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/poly1305/src/backend/autodetect.rs
+++ b/poly1305/src/backend/autodetect.rs
@@ -1,7 +1,7 @@
 //! Autodetection support for AVX2 CPU intrinsics on x86 CPUs, with fallback
 //! to the "soft" backend when it's unavailable.
 
-use universal_hash::{UhfClosure, UniversalHash, consts::U16, crypto_common::BlockSizeUser};
+use universal_hash::{UhfClosure, UniversalHash, common::BlockSizeUser, consts::U16};
 
 use crate::{Block, Key, Tag, backend};
 use core::mem::ManuallyDrop;

--- a/poly1305/src/backend/avx2.rs
+++ b/poly1305/src/backend/avx2.rs
@@ -19,8 +19,8 @@
 use universal_hash::{
     UhfBackend,
     array::Array,
+    common::{BlockSizeUser, ParBlocksSizeUser},
     consts::{U4, U16},
-    crypto_common::{BlockSizeUser, ParBlocksSizeUser},
 };
 
 use crate::{Block, Key, Tag};

--- a/poly1305/src/backend/soft.rs
+++ b/poly1305/src/backend/soft.rs
@@ -14,8 +14,8 @@
 
 use universal_hash::{
     UhfBackend, UhfClosure, UniversalHash,
+    common::{BlockSizeUser, ParBlocksSizeUser},
     consts::{U1, U16},
-    crypto_common::{BlockSizeUser, ParBlocksSizeUser},
 };
 
 use crate::{Block, Key, Tag};

--- a/poly1305/src/lib.rs
+++ b/poly1305/src/lib.rs
@@ -11,8 +11,8 @@ pub use universal_hash;
 use core::fmt::{self, Debug};
 use universal_hash::{
     KeyInit, UhfClosure, UniversalHash,
+    common::{BlockSizeUser, KeySizeUser},
     consts::{U16, U32},
-    crypto_common::{BlockSizeUser, KeySizeUser},
 };
 
 mod backend;

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 
 [dependencies]
 cpubits = "0.1.0-rc.1"
-universal-hash = { version = "0.6.0-rc.7", default-features = false }
+universal-hash = { version = "0.6.0-rc.8", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/polyval/src/backend/autodetect.rs
+++ b/polyval/src/backend/autodetect.rs
@@ -6,8 +6,8 @@ use core::mem::ManuallyDrop;
 use universal_hash::{
     KeyInit, Reset, UhfClosure, UniversalHash,
     array::ArraySize,
+    common::{BlockSizeUser, KeySizeUser},
     consts::U16,
-    crypto_common::{BlockSizeUser, KeySizeUser},
     typenum::{Const, ToUInt, U},
 };
 

--- a/polyval/src/backend/clmul.rs
+++ b/polyval/src/backend/clmul.rs
@@ -12,8 +12,8 @@ use core::arch::x86_64::*;
 use universal_hash::{
     KeyInit, ParBlocks, Reset, UhfBackend,
     array::ArraySize,
+    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     consts::U16,
-    crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     typenum::{Const, ToUInt, U},
 };
 

--- a/polyval/src/backend/pmull.rs
+++ b/polyval/src/backend/pmull.rs
@@ -20,8 +20,8 @@ use core::{arch::aarch64::*, mem};
 use universal_hash::{
     KeyInit, ParBlocks, Reset, UhfBackend,
     array::ArraySize,
+    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     consts::U16,
-    crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     typenum::{Const, ToUInt, U},
 };
 

--- a/polyval/src/backend/soft.rs
+++ b/polyval/src/backend/soft.rs
@@ -16,8 +16,8 @@ use crate::{Block, Key, Tag};
 use soft_impl::*;
 use universal_hash::{
     KeyInit, Reset, UhfBackend, UhfClosure, UniversalHash,
+    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
     consts::{U1, U16},
-    crypto_common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
 };
 
 #[cfg(feature = "zeroize")]

--- a/polyval/src/backend/soft/soft32.rs
+++ b/polyval/src/backend/soft/soft32.rs
@@ -35,7 +35,7 @@ use core::{
     num::Wrapping,
     ops::{Add, Mul},
 };
-use universal_hash::crypto_common::array::{Array, sizes::U4};
+use universal_hash::common::array::{Array, sizes::U4};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;

--- a/polyval/src/backend/soft/soft64.rs
+++ b/polyval/src/backend/soft/soft64.rs
@@ -15,7 +15,7 @@ use core::{
     num::Wrapping,
     ops::{Add, Mul},
 };
-use universal_hash::crypto_common::array::{Array, sizes::U8};
+use universal_hash::common::array::{Array, sizes::U8};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;

--- a/polyval/tests/lib.rs
+++ b/polyval/tests/lib.rs
@@ -3,7 +3,7 @@
 use hex_literal::hex;
 use polyval::{
     BLOCK_SIZE, Polyval, PolyvalGeneric,
-    universal_hash::{KeyInit, Reset, UniversalHash, crypto_common::KeySizeUser, typenum::U16},
+    universal_hash::{KeyInit, Reset, UniversalHash, common::KeySizeUser, typenum::U16},
 };
 
 //


### PR DESCRIPTION
Makes use of the `universal_hash::common` re-export.

It seems like the deprecation of `universal_hash::crypto_common` isn't working, though.