### PR TITLE
polyval: expand CI tests

### DIFF
--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -21,32 +21,23 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  build:
+  # Ensure crate builds on a `no_std` target
+  build-no_std:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.85.0 # MSRV
-          - stable
-        target:
-          - thumbv7em-none-eabi
-          - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release
-      - run: cargo build --target ${{ matrix.target }} --release --features zeroize
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - run: cargo check --target thumbv7em-none-eabi --release --features zeroize
 
   # Tests with CPU feature detection enabled
-  autodetect:
-    runs-on: ubuntu-latest
+  test-autodetect:
     strategy:
       matrix:
         include:
-          # 32-bit Linux
+          # `x86` Linux (32-bit)
           - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
@@ -54,11 +45,28 @@ jobs:
             rust: stable
             deps: sudo apt update && sudo apt install gcc-multilib
 
-          # 64-bit Linux
+          # `x86_64` Linux
           - target: x86_64-unknown-linux-gnu
             rust: 1.85.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
+
+          # `aarch64` Linux
+          - target: aarch64-unknown-linux-gnu
+            rust: 1.85.0 # MSRV
+            runner: ubuntu-24.04-arm
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+            runner: ubuntu-24.04-arm
+
+          # `aarch64` macOS
+          - target: aarch64-apple-darwin
+            rust: 1.85.0 # MSRV
+            runner: macos-latest
+          - target: aarch64-apple-darwin
+            rust: stable
+            runner: macos-latest
+    runs-on: ${{ matrix.runner != '' && matrix.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -67,19 +75,19 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }} --release
-      - run: cargo test --target ${{ matrix.target }} --release --features zeroize
-      - run: cargo test --target ${{ matrix.target }} --release --all-features
+      - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features zeroize
+      - run: cargo test --target ${{ matrix.target }} --all-features --release
 
   # Tests for the CLMUL backend (forced)
-  clmul:
+  test-clmul:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Ctarget-cpu=haswell -Ctarget-feature=+sse2,+sse4.1
     strategy:
       matrix:
         include:
-          # 32-bit Linux
+          # `x86` Linux (32-bit)
           - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
@@ -87,7 +95,7 @@ jobs:
             rust: stable
             deps: sudo apt update && sudo apt install gcc-multilib
 
-          # 64-bit Linux
+          # `x86_64` Linux
           - target: x86_64-unknown-linux-gnu
             rust: 1.85.0 # MSRV
           - target: x86_64-unknown-linux-gnu
@@ -105,14 +113,14 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Tests for the portable software backend (forced)
-  soft:
+  test-soft:
     env:
-      RUSTFLAGS: "-Dwarnings --cfg polyval_force_soft"
+      RUSTFLAGS: '-Dwarnings --cfg polyval_backend="soft"'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          # 32-bit Linux
+          # `x86` Linux (32-bit)
           - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
@@ -120,7 +128,7 @@ jobs:
             rust: stable
             deps: sudo apt update && sudo apt install gcc-multilib
 
-          # 64-bit Linux
+          # `x86_64` Linux
           - target: x86_64-unknown-linux-gnu
             rust: 1.85.0 # MSRV
           - target: x86_64-unknown-linux-gnu
@@ -138,13 +146,12 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
   # Cross-compiled tests
-  cross:
+  test-cross:
     strategy:
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-          - target: powerpc-unknown-linux-gnu
-
+          - target: armv7-unknown-linux-gnueabi # ARMv7 (32-bit)
+          - target: powerpc-unknown-linux-gnu   # PPC32 (big endian)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -158,24 +165,34 @@ jobs:
       - run: cross test --target ${{ matrix.target }} --release --features zeroize
       - run: cross test --target ${{ matrix.target }} --release --all-features
 
-  # ARMv8 cross-compiled tests for PMULL intrinsics (nightly-only)
-  armv8:
+  # Test using `cargo miri`
+  test-miri:
+    runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "-Dwarnings --cfg polyval_armv8"
+      MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-strict-provenance"
     strategy:
       matrix:
-        include:
-          - target: aarch64-unknown-linux-gnu
-            rust: nightly
-    runs-on: ubuntu-latest
+        target:
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v6
-      - run: ${{ matrix.deps }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: rustup component add miri && cargo miri setup
+      - run: cargo miri test --target ${{ matrix.target }} --lib
+
+  # Test WASM using `wasmtime`
+  test-wasm:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: "wasmtime"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-      - run: cargo install cross
-      - run: cross test --target ${{ matrix.target }} --release    
-      - run: cross test --target ${{ matrix.target }} --release --features zeroize
-      - run: cross test --target ${{ matrix.target }} --release --all-features
+          toolchain: stable
+          targets: wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1 --all-features
+      - run: cargo test --target wasm32-wasip1 --all-features --release

--- a/polyval/src/backend/soft.rs
+++ b/polyval/src/backend/soft.rs
@@ -227,8 +227,15 @@ impl Zeroize for FieldElement {
     }
 }
 
-/// Multiplication in GF(2)[X], truncated to the low 64-bits, with "holes" (sequences of zeroes) to
-/// avoid carry spilling, as specified in the four masking operands (`m0`-`m4`).
+/// Multiplication in GF(2)[X], implemented generically and wrapped as `bmul32` and `bmul64`.
+///
+/// Uses "holes" (sequences of zeroes) to avoid carry spilling, as specified in the four masking
+/// operands (`m0`-`m4`), which should have full-width values with the following bit patterns:
+///
+/// - `m0`: `0b100010001...0001` (e.g. `0x1111_1111u32`)
+/// - `m1`: `0b100010001...00010` (e.g. `0x2222_2222u32`)
+/// - `m2`: `0b100010001...000100` (e.g. `0x4444_4444u32`)
+/// - `m3`: `0b100010001...0001000` (e.g. `0x8888_8888u32`)
 ///
 /// When carries do occur, they wind up in a "hole" and are subsequently masked out of the result.
 #[inline]


### PR DESCRIPTION
- Test on `aarch64` runners for Linux and macOS
- Remove cross-compiled tests when we have native runners
- Add ARMv7 cross-compiled tests
- Test on Miri for both `aarch64` and `x86_64`
- Test on `wasm32-wasip1` using `wasmtime`