### PR TITLE
polyval: DRY out `bmul*` mask calculation

### DIFF
--- a/polyval/src/backend/soft/soft32.rs
+++ b/polyval/src/backend/soft/soft32.rs
@@ -144,7 +144,7 @@ pub(super) fn karatsuba(h: U32x4, y: U32x4) -> U32x8 {
 /// Carryless multiplication in GF(2)[X], truncated to the low 32-bits.
 #[inline]
 fn bmul32(x: u32, y: u32) -> u32 {
-    super::bmul(x, y, 0x1111_1111, 0x2222_2222, 0x4444_4444, 0x8888_8888)
+    super::bmul(x, y, 0x1111_1111)
 }
 
 /// Reduce the 256-bit carryless product of Karatsuba modulo the POLYVAL polynomial.

--- a/polyval/src/backend/soft/soft64.rs
+++ b/polyval/src/backend/soft/soft64.rs
@@ -73,14 +73,7 @@ pub(super) fn karatsuba(h: U64x2, y: U64x2) -> U64x4 {
 /// Carryless multiplication in GF(2)[X], truncated to the low 64-bits.
 #[inline]
 fn bmul64(x: u64, y: u64) -> u64 {
-    super::bmul(
-        x,
-        y,
-        0x1111_1111_1111_1111,
-        0x2222_2222_2222_2222,
-        0x4444_4444_4444_4444,
-        0x8888_8888_8888_8888,
-    )
+    super::bmul(x, y, 0x1111_1111_1111_1111)
 }
 
 /// Reduce the 256-bit carryless product of Karatsuba modulo the POLYVAL polynomial.


### PR DESCRIPTION
It can be calculated from a single value