### PR TITLE
polyval: use `FieldElement` as common internal representation

### DIFF
--- a/polyval/src/backend.rs
+++ b/polyval/src/backend.rs
@@ -2,7 +2,14 @@
 
 mod soft;
 
+use crate::{BLOCK_SIZE, Block};
+use core::fmt;
+use core::fmt::Debug;
+use core::ops::{Add, Mul};
 use cpubits::cfg_if;
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 cfg_if! {
     if #[cfg(all(target_arch = "aarch64", not(polyval_backend = "soft")))] {
@@ -23,7 +30,137 @@ cfg_if! {
     }
 }
 
-/// **POLYVAL**: GHASH-like universal hash over GF(2^128).
-//
-// We have to define a type alias here, or existing code will break.
-pub type Polyval = PolyvalGeneric<8>;
+/// An element in POLYVAL's field.
+///
+/// This type represents an element of the binary field GF(2^128) modulo the irreducible polynomial
+/// `x^128 + x^127 + x^126 + x^121 + 1` as described in [RFC8452 §3].
+///
+/// # Representation
+///
+/// The element is represented as 16-bytes in little-endian order.
+///
+/// Arithmetic in POLYVAL's field has the following properties:
+/// - All arithmetic operations are performed modulo the polynomial above.
+/// - Addition is equivalent to the XOR operation applied to the two field elements
+/// - Multiplication is carryless
+///
+/// [RFC8452 §3]: https://tools.ietf.org/html/rfc8452#section-3
+#[derive(Clone, Copy, Default, Eq, PartialEq)] // TODO(tarcieri): constant-time `*Eq`?
+#[repr(C, align(16))] // Make ABI and alignment compatible with SIMD registers
+pub(crate) struct FieldElement([u8; BLOCK_SIZE]);
+
+impl Debug for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldElement(")?;
+        for byte in self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl From<Block> for FieldElement {
+    #[inline]
+    fn from(block: Block) -> Self {
+        Self(block.into())
+    }
+}
+
+impl From<&Block> for FieldElement {
+    #[inline]
+    fn from(block: &Block) -> Self {
+        Self::from(*block)
+    }
+}
+
+impl From<FieldElement> for Block {
+    #[inline]
+    fn from(fe: FieldElement) -> Self {
+        fe.0.into()
+    }
+}
+
+impl From<&FieldElement> for Block {
+    #[inline]
+    fn from(fe: &FieldElement) -> Self {
+        Self::from(*fe)
+    }
+}
+
+impl From<[u8; BLOCK_SIZE]> for FieldElement {
+    #[inline]
+    fn from(bytes: [u8; BLOCK_SIZE]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<u128> for FieldElement {
+    #[inline]
+    fn from(x: u128) -> Self {
+        Self(x.to_le_bytes())
+    }
+}
+
+impl From<FieldElement> for u128 {
+    #[inline]
+    fn from(fe: FieldElement) -> Self {
+        u128::from_le_bytes(fe.0)
+    }
+}
+
+impl Add for FieldElement {
+    type Output = Self;
+
+    /// Adds two POLYVAL field elements.
+    ///
+    /// In POLYVAL's field, addition is the equivalent operation to XOR.
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        (u128::from(self) ^ u128::from(rhs)).into()
+    }
+}
+
+impl Mul for FieldElement {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        let v = soft::karatsuba(self.into(), rhs.into());
+        soft::mont_reduce(v).into()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for FieldElement {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    const A: [u8; 16] = hex!("66e94bd4ef8a2c3b884cfa59ca342b2e");
+    const B: [u8; 16] = hex!("ff000000000000000000000000000000");
+
+    #[test]
+    fn fe_add() {
+        let a = FieldElement::from(A);
+        let b = FieldElement::from(B);
+
+        let expected = FieldElement::from(hex!("99e94bd4ef8a2c3b884cfa59ca342b2e"));
+        assert_eq!(a + b, expected);
+        assert_eq!(b + a, expected);
+    }
+
+    #[test]
+    fn fe_mul() {
+        let a = FieldElement::from(A);
+        let b = FieldElement::from(B);
+
+        let expected = FieldElement::from(hex!("ebe563401e7e91ea3ad6426b8140c394"));
+        assert_eq!(a * b, expected);
+        assert_eq!(b * a, expected);
+    }
+}

--- a/polyval/src/backend/soft/soft64.rs
+++ b/polyval/src/backend/soft/soft64.rs
@@ -30,7 +30,7 @@ impl From<U64x2> for FieldElement {
 /// Uses a Karatsuba decomposition in which the 128x128 multiplication is reduced to three 64x64
 /// multiplications together with a bit-reversal trick to efficiently recover the high half.
 #[inline]
-pub(super) fn karatsuba(h: U64x2, y: U64x2) -> U64x4 {
+pub(crate) fn karatsuba(h: U64x2, y: U64x2) -> U64x4 {
     // Karatsuba input decomposition for H
     let h0 = h.0;
     let h1 = h.1;
@@ -82,7 +82,7 @@ fn bmul64(x: u64, y: u64) -> u64 {
 /// polynomial `x^128 + x^127 + x^126 + x^121 + 1`. This is closely related to GHASH reduction but
 /// the polynomial's bit order is reversed in POLYVAL.
 #[inline]
-pub(super) fn mont_reduce(v: U64x4) -> U64x2 {
+pub(crate) fn mont_reduce(v: U64x4) -> U64x2 {
     let (v0, mut v1, mut v2, mut v3) = v;
     v2 ^= v0 ^ (v0 >> 1) ^ (v0 >> 2) ^ (v0 >> 7);
     v1 ^= (v0 << 63) ^ (v0 << 62) ^ (v0 << 57);

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -9,7 +9,7 @@
 mod backend;
 mod mulx;
 
-pub use crate::{backend::Polyval, backend::PolyvalGeneric, mulx::mulx};
+pub use crate::{backend::PolyvalGeneric, mulx::mulx};
 pub use universal_hash;
 
 impl<const N: usize> core::fmt::Debug for PolyvalGeneric<N> {
@@ -32,3 +32,6 @@ pub type Block = universal_hash::Block<Polyval>;
 
 /// POLYVAL tags (16-bytes)
 pub type Tag = universal_hash::Block<Polyval>;
+
+/// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+pub type Polyval = PolyvalGeneric<8>;


### PR DESCRIPTION
Continued work towards consolidating and simplifying the implementation.

This uses a simple `[u8; 16]` as the internal representation, effectively deferring the decoding step to SIMD registers, which has been moved to a `From<FieldElement>` impl for both `__m128i` on `x86`/`x86_64` and `uint8x16_t` on ARMv8. SIMD registers are still loaded using the relevant intrinsics (`__mm_loadu_si128` and `vld1q_u8` respectively), though `FieldElement` now uses a `repr(C, align(16))` layout which should permit sound typecasts to registers in the future if we desire.

With this change, all three backends: `x86`/`x86_64`, `armv8`, and `soft`, all use the `FieldElement` type as their internal representation for the `Polyval` type. This should make it possible to consolidate the implementation into one that can be shared across backends.

With a little more work we can potentially expose `FieldElement` as a `hazmat` type, which would be useful for the crates which build constructions on top of it (e.g. `belt-dwp`, `mgm`)