### PR TITLE
polyval: have `soft` use `FieldElement` operands

### DIFF
--- a/polyval/src/field_element.rs
+++ b/polyval/src/field_element.rs
@@ -142,9 +142,10 @@ impl Add for FieldElement {
 impl Mul for FieldElement {
     type Output = Self;
 
+    #[inline]
     fn mul(self, rhs: Self) -> Self {
-        let v = soft::karatsuba(self.into(), rhs.into());
-        soft::mont_reduce(v).into()
+        let v = soft::karatsuba(self, rhs);
+        soft::mont_reduce(v)
     }
 }
 

--- a/polyval/src/field_element/armv8.rs
+++ b/polyval/src/field_element/armv8.rs
@@ -26,7 +26,9 @@ use universal_hash::{
     typenum::{Const, ToUInt, U},
 };
 
-/// Montgomery reduction polynomial
+/// POLYVAL reduction polynomial (`x^128 + x^127 + x^126 + x^121 + 1`) encoded in little-endian
+/// GF(2)[x] form with reflected reduction terms arising from folding the upper 128-bits of the
+/// product into the lower half during modular reduction.
 const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).


### PR DESCRIPTION
Changes the operands and reduction return type to `FieldElement`, so the caller doesn't need to use `Into`