### PR TITLE
polyval: consolidate single `PolyvalGeneric` struct

### DIFF
--- a/polyval/benches/polyval.rs
+++ b/polyval/benches/polyval.rs
@@ -4,10 +4,7 @@
 
 extern crate test;
 
-use polyval::{
-    Polyval,
-    universal_hash::{KeyInit, UniversalHash},
-};
+use polyval::{Polyval, universal_hash::UniversalHash};
 use test::Bencher;
 
 // TODO(tarcieri): move this into the `universal-hash` crate

--- a/polyval/src/field_element/armv8.rs
+++ b/polyval/src/field_element/armv8.rs
@@ -13,154 +13,96 @@
 //! For more information about PMULL, see:
 //! - <https://developer.arm.com/documentation/100069/0608/A64-SIMD-Vector-Instructions/PMULL--PMULL2--vector->
 //! - <https://eprint.iacr.org/2015/688.pdf>
+
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use super::FieldElement;
-use crate::{Block, Key, Tag};
+use crate::Block;
 use core::{arch::aarch64::*, mem};
-use universal_hash::{
-    KeyInit, ParBlocks, Reset, UhfBackend,
-    array::ArraySize,
-    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
-    consts::U16,
-    typenum::{Const, ToUInt, U},
-};
+use universal_hash::array::{Array, ArraySize};
 
-/// POLYVAL reduction polynomial (`x^128 + x^127 + x^126 + x^121 + 1`) encoded in little-endian
-/// GF(2)[x] form with reflected reduction terms arising from folding the upper 128-bits of the
-/// product into the lower half during modular reduction.
-const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
+/// 128-bit SIMD register type.
+pub(super) type Simd128 = uint8x16_t;
 
-/// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+/// Perform carryless multiplication of `y` by `h` and return the result.
 ///
-/// Parameterized on a constant that determines how many
-/// blocks to process at once: higher numbers use more memory,
-/// and require more time to re-key, but process data significantly
-/// faster.
+/// # Safety
+/// It is the caller's responsibility to ensure the host CPU is capable of PMULL and NEON
+/// instructions.
+// TODO(tarcieri): investigate ordering optimizations and fusions e.g.`fuse-crypto-eor`
+#[inline]
+#[target_feature(enable = "aes,neon")]
+pub(super) unsafe fn polymul(y: Simd128, h: Simd128) -> Simd128 {
+    let (h, m, l) = karatsuba1(h, y);
+    let (h, l) = karatsuba2(h, m, l);
+    mont_reduce(h, l)
+}
+
+/// Process an individual block.
 ///
-/// (This constant is not used when acceleration is not enabled.)
-#[derive(Clone)]
-pub struct Polyval<const N: usize = 8> {
-    /// Powers of H in descending order.
-    ///
-    /// (H^N, H^(N-1)...H)
-    h: [FieldElement; N],
+/// # Safety
+/// It is the caller's responsibility to ensure the host CPU is capable of PMULL and NEON
+/// instructions.
+#[inline]
+#[target_feature(enable = "aes,neon")]
+pub(super) unsafe fn proc_block(h: FieldElement, y: FieldElement, x: &Block) -> FieldElement {
+    let y = veorq_u8(y.into(), vld1q_u8(x.as_ptr()));
+    polymul(y, h.into()).into()
+}
+
+/// Process multiple blocks in parallel.
+///
+/// # Safety
+/// It is the caller's responsibility to ensure the host CPU is capable of PMULL and NEON
+/// instructions.
+#[target_feature(enable = "aes,neon")]
+pub(super) unsafe fn proc_par_blocks<const N: usize, U: ArraySize>(
+    powers_of_h: &[FieldElement; N],
     y: FieldElement,
-}
+    blocks: &Array<Block, U>,
+) -> FieldElement {
+    unsafe {
+        let mut h = vdupq_n_u8(0);
+        let mut m = vdupq_n_u8(0);
+        let mut l = vdupq_n_u8(0);
 
-impl<const N: usize> KeySizeUser for Polyval<N> {
-    type KeySize = U16;
-}
-
-impl<const N: usize> Polyval<N> {
-    /// Initialize POLYVAL with the given `H` field element and initial block
-    pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
-        Self {
-            h: FieldElement::from(h).powers_of_h(),
-            y: init_block.into(),
-        }
-    }
-}
-
-impl<const N: usize> KeyInit for Polyval<N> {
-    /// Initialize POLYVAL with the given `H` field element
-    fn new(h: &Key) -> Self {
-        Self::new_with_init_block(h, 0)
-    }
-}
-
-impl<const N: usize> BlockSizeUser for Polyval<N> {
-    type BlockSize = U16;
-}
-
-impl<const N: usize> ParBlocksSizeUser for Polyval<N>
-where
-    U<N>: ArraySize,
-    Const<N>: ToUInt,
-{
-    type ParBlocksSize = U<N>;
-}
-
-impl<const N: usize> UhfBackend for Polyval<N>
-where
-    U<N>: ArraySize,
-    Const<N>: ToUInt,
-{
-    fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
-        unsafe {
-            let mut h = vdupq_n_u8(0);
-            let mut m = vdupq_n_u8(0);
-            let mut l = vdupq_n_u8(0);
-
-            // Note: Manually unrolling this loop did not help in benchmarks.
-            for i in (0..N).rev() {
-                let mut x = vld1q_u8(blocks[i].as_ptr());
-                if i == 0 {
-                    x = veorq_u8(x, self.y.into());
-                }
-                let y = self.h[i];
-                let (hh, mm, ll) = karatsuba1(x, y.into());
-                h = veorq_u8(h, hh);
-                m = veorq_u8(m, mm);
-                l = veorq_u8(l, ll);
+        // Note: Manually unrolling this loop did not help in benchmarks.
+        for i in (0..N).rev() {
+            let mut x = vld1q_u8(blocks[i].as_ptr());
+            if i == 0 {
+                x = veorq_u8(x, y.into());
             }
-
-            let (h, l) = karatsuba2(h, m, l);
-            self.y = mont_reduce(h, l).into();
+            let (hh, mm, ll) = karatsuba1(x, powers_of_h[i].into());
+            h = veorq_u8(h, hh);
+            m = veorq_u8(m, mm);
+            l = veorq_u8(l, ll);
         }
-    }
 
-    fn proc_block(&mut self, x: &Block) {
-        unsafe {
-            let y = veorq_u8(self.y.into(), vld1q_u8(x.as_ptr()));
-            self.y = polymul(y, self.h[N - 1].into()).into();
-        }
+        let (h, l) = karatsuba2(h, m, l);
+        mont_reduce(h, l).into()
     }
 }
 
-impl<const N: usize> Reset for Polyval<N> {
-    fn reset(&mut self) {
-        self.y = FieldElement::default();
-    }
-}
-
-impl<const N: usize> Polyval<N> {
-    /// Get POLYVAL output.
-    pub(crate) fn finalize(self) -> Tag {
-        self.y.into()
-    }
-}
-
-impl From<FieldElement> for uint8x16_t {
+impl From<FieldElement> for Simd128 {
     #[inline]
-    fn from(fe: FieldElement) -> uint8x16_t {
+    fn from(fe: FieldElement) -> Simd128 {
         unsafe { vld1q_u8(fe.0.as_ptr()) }
     }
 }
 
-impl From<uint8x16_t> for FieldElement {
+impl From<Simd128> for FieldElement {
     #[inline]
-    fn from(fe: uint8x16_t) -> FieldElement {
+    fn from(fe: Simd128) -> FieldElement {
         let mut ret = FieldElement::default();
         unsafe { vst1q_u8(ret.0.as_mut_ptr(), fe) }
         ret
     }
 }
 
-/// Multiply "y" by "h" and return the result.
-// TODO(tarcieri): investigate ordering optimizations and fusions e.g.`fuse-crypto-eor`
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn polymul(y: uint8x16_t, h: uint8x16_t) -> uint8x16_t {
-    let (h, m, l) = karatsuba1(h, y);
-    let (h, l) = karatsuba2(h, m, l);
-    mont_reduce(h, l)
-}
-
 /// Karatsuba decomposition for `x*y`.
 #[inline]
-#[target_feature(enable = "neon")]
-unsafe fn karatsuba1(x: uint8x16_t, y: uint8x16_t) -> (uint8x16_t, uint8x16_t, uint8x16_t) {
+#[target_feature(enable = "aes,neon")]
+unsafe fn karatsuba1(x: Simd128, y: Simd128) -> (Simd128, Simd128, Simd128) {
     // First Karatsuba step: decompose x and y.
     //
     // (x1*y0 + x0*y1) = (x1+x0) * (y1+y0) + (x1*y1) + (x0*y0)
@@ -179,7 +121,7 @@ unsafe fn karatsuba1(x: uint8x16_t, y: uint8x16_t) -> (uint8x16_t, uint8x16_t, u
 /// Karatsuba combine.
 #[inline]
 #[target_feature(enable = "neon")]
-unsafe fn karatsuba2(h: uint8x16_t, m: uint8x16_t, l: uint8x16_t) -> (uint8x16_t, uint8x16_t) {
+unsafe fn karatsuba2(h: Simd128, m: Simd128, l: Simd128) -> (Simd128, Simd128) {
     // Second Karatsuba step: combine into a 2n-bit product.
     //
     // m0 ^= l0 ^ h0 // = m0^(l0^h0)
@@ -218,9 +160,14 @@ unsafe fn karatsuba2(h: uint8x16_t, m: uint8x16_t, l: uint8x16_t) -> (uint8x16_t
     (x23, x01)
 }
 
+/// POLYVAL reduction polynomial (`x^128 + x^127 + x^126 + x^121 + 1`) encoded in little-endian
+/// GF(2)[x] form with reflected reduction terms arising from folding the upper 128-bits of the
+/// product into the lower half during modular reduction.
+const POLY: u128 = (1 << 127) | (1 << 126) | (1 << 121) | (1 << 63) | (1 << 62) | (1 << 57);
+
 #[inline]
-#[target_feature(enable = "neon")]
-unsafe fn mont_reduce(x23: uint8x16_t, x01: uint8x16_t) -> uint8x16_t {
+#[target_feature(enable = "aes,neon")]
+unsafe fn mont_reduce(x23: Simd128, x01: Simd128) -> Simd128 {
     // Perform the Montgomery reduction over the 256-bit X.
     //    [A1:A0] = X0 • poly
     //    [B1:B0] = [X0 ⊕ A1 : X1 ⊕ A0]
@@ -236,8 +183,8 @@ unsafe fn mont_reduce(x23: uint8x16_t, x01: uint8x16_t) -> uint8x16_t {
 
 /// Multiplies the low bits in `a` and `b`.
 #[inline]
-#[target_feature(enable = "neon")]
-unsafe fn pmull(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+#[target_feature(enable = "aes,neon")]
+unsafe fn pmull(a: Simd128, b: Simd128) -> Simd128 {
     mem::transmute(vmull_p64(
         vgetq_lane_u64(vreinterpretq_u64_u8(a), 0),
         vgetq_lane_u64(vreinterpretq_u64_u8(b), 0),
@@ -246,19 +193,10 @@ unsafe fn pmull(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 
 /// Multiplies the high bits in `a` and `b`.
 #[inline]
-#[target_feature(enable = "neon")]
-unsafe fn pmull2(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+#[target_feature(enable = "aes,neon")]
+unsafe fn pmull2(a: Simd128, b: Simd128) -> Simd128 {
     mem::transmute(vmull_p64(
         vgetq_lane_u64(vreinterpretq_u64_u8(a), 1),
         vgetq_lane_u64(vreinterpretq_u64_u8(b), 1),
     ))
 }
-// TODO(tarcieri): zeroize support
-// #[cfg(feature = "zeroize")]
-// impl Drop for Polyval<N> {
-//     fn drop(&mut self) {
-//         use zeroize::Zeroize;
-//         self.h.zeroize();
-//         self.y.zeroize();
-//     }
-// }

--- a/polyval/src/field_element/soft/soft32.rs
+++ b/polyval/src/field_element/soft/soft32.rs
@@ -56,7 +56,7 @@ impl FieldElement {
 /// multiplications, hence nine 32x32 multiplications. With the bit-reversal trick, we have to
 /// perform 18 32x32 multiplications.
 #[inline]
-pub(crate) fn karatsuba(h: FieldElement, y: FieldElement) -> [u32; 8] {
+pub(super) fn karatsuba(h: FieldElement, y: FieldElement) -> [u32; 8] {
     let hw = h.to_u32x4();
     let yw = y.to_u32x4();
     let hwr = [
@@ -149,7 +149,7 @@ fn bmul32(x: u32, y: u32) -> u32 {
 ///
 /// This is closely related to GHASH reduction but the bit order is reversed in POLYVAL.
 #[inline]
-pub(crate) fn mont_reduce(mut zw: [u32; 8]) -> FieldElement {
+pub(super) fn mont_reduce(mut zw: [u32; 8]) -> FieldElement {
     for i in 0..4 {
         let lw = zw[i];
         zw[i + 4] ^= lw ^ (lw >> 1) ^ (lw >> 2) ^ (lw >> 7);

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -9,14 +9,21 @@
 mod field_element;
 mod mulx;
 
-pub use crate::{field_element::PolyvalGeneric, mulx::mulx};
+pub use crate::mulx::mulx;
 pub use universal_hash;
 
-impl<const N: usize> core::fmt::Debug for PolyvalGeneric<N> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
-        write!(f, "PolyvalGeneric<{}> {{ ... }}", N)
-    }
-}
+use core::fmt::{self, Debug};
+use field_element::{FieldElement, InitToken, detect_intrinsics};
+use universal_hash::{
+    KeyInit, ParBlocks, Reset, UhfBackend, UhfClosure, UniversalHash,
+    array::{Array, ArraySize},
+    common::{BlockSizeUser, KeySizeUser, ParBlocksSizeUser},
+    consts::U16,
+    typenum::{Const, ToUInt, U},
+};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 /// Size of a POLYVAL block in bytes
 pub const BLOCK_SIZE: usize = 16;
@@ -25,13 +32,133 @@ pub const BLOCK_SIZE: usize = 16;
 pub const KEY_SIZE: usize = 16;
 
 /// POLYVAL keys (16-bytes)
-pub type Key = universal_hash::Key<Polyval>;
+pub type Key = Array<u8, U16>;
 
 /// POLYVAL blocks (16-bytes)
-pub type Block = universal_hash::Block<Polyval>;
+pub type Block = Array<u8, U16>;
 
 /// POLYVAL tags (16-bytes)
-pub type Tag = universal_hash::Block<Polyval>;
+pub type Tag = Array<u8, U16>;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
-pub type Polyval = PolyvalGeneric<8>;
+///
+/// This type alias uses the default amount of parallelism for the target (`8` for `aarch64`/`x86`,
+/// `1` for other targets using a pure Rust fallback implementation).
+pub type Polyval = PolyvalGeneric<{ FieldElement::DEFAULT_PARALLELISM }>;
+
+/// **POLYVAL**: GHASH-like universal hash over GF(2^128).
+///
+/// Parameterized on a constant that determines how many blocks to process at once: higher numbers
+/// use more memory, and require more time to re-key, but process data significantly faster.
+///
+/// (This constant is not used when acceleration is not enabled.)
+#[derive(Clone)]
+pub struct PolyvalGeneric<const N: usize = { FieldElement::DEFAULT_PARALLELISM }> {
+    /// Powers of H in descending order.
+    ///
+    /// (H^N, H^(N-1)...H)
+    powers_of_h: [FieldElement; N],
+
+    /// Accumulator for POLYVAL computation.
+    y: FieldElement,
+
+    /// Token for accessing CPU feature detection results.
+    has_intrinsics: InitToken,
+}
+
+impl<const N: usize> PolyvalGeneric<N> {
+    /// Initialize POLYVAL with the given `H` field element.
+    #[must_use]
+    pub fn new(h: &Key) -> Self {
+        Self::new_with_init_block(h, 0)
+    }
+
+    /// Initialize POLYVAL with the given `H` field element and initial block.
+    #[must_use]
+    pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
+        let (token, _has_intrinsics) = detect_intrinsics();
+        Self {
+            powers_of_h: FieldElement::from(h).powers_of_h(),
+            y: init_block.into(),
+            has_intrinsics: token,
+        }
+    }
+
+    /// Get `h` from the powers-of-`H`.
+    #[inline]
+    pub(crate) fn h(&self) -> FieldElement {
+        self.powers_of_h[N - 1]
+    }
+}
+
+impl<const N: usize> KeyInit for PolyvalGeneric<N> {
+    fn new(h: &Key) -> Self {
+        Self::new(h)
+    }
+}
+
+impl<const N: usize> KeySizeUser for PolyvalGeneric<N> {
+    type KeySize = U16;
+}
+
+impl<const N: usize> BlockSizeUser for PolyvalGeneric<N> {
+    type BlockSize = U16;
+}
+
+impl<const N: usize> ParBlocksSizeUser for PolyvalGeneric<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
+    type ParBlocksSize = U<N>;
+}
+
+impl<const N: usize> UniversalHash for PolyvalGeneric<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
+    fn update_with_backend(&mut self, f: impl UhfClosure<BlockSize = Self::BlockSize>) {
+        f.call(self);
+    }
+
+    fn finalize(self) -> Tag {
+        self.y.into()
+    }
+}
+
+#[allow(clippy::unit_arg)]
+impl<const N: usize> UhfBackend for PolyvalGeneric<N>
+where
+    U<N>: ArraySize,
+    Const<N>: ToUInt,
+{
+    fn proc_block(&mut self, block: &Block) {
+        self.y = FieldElement::proc_block(self.h(), self.y, block, self.has_intrinsics);
+    }
+
+    fn proc_par_blocks(&mut self, blocks: &ParBlocks<Self>) {
+        self.y =
+            FieldElement::proc_par_blocks(&self.powers_of_h, self.y, blocks, self.has_intrinsics);
+    }
+}
+
+impl<const N: usize> Reset for PolyvalGeneric<N> {
+    fn reset(&mut self) {
+        self.y = FieldElement::default();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<const N: usize> Drop for PolyvalGeneric<N> {
+    fn drop(&mut self) {
+        self.powers_of_h.zeroize();
+        self.y.zeroize();
+    }
+}
+
+impl<const N: usize> Debug for PolyvalGeneric<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "PolyvalGeneric<{}> {{ ... }}", N)
+    }
+}


### PR DESCRIPTION
Consolidates the many (nested, via unions!) repeated `Polyval` structs found throughout the crate for each backend into a single `Polyval(Generic)` struct which imlements the `universal-hash` interface in a single place.

`FieldElement` now defers decoding into SIMD registers until we're ready to actually perform a field operation, so we can use that as a common type for all field backends (and already implemented this in previous commits).

Backends are now just free functions that operate on `FieldElement`, making them dramatically simpler.