### PR TITLE
polyval: use intrinsics when computing powers of `H`

### DIFF
--- a/polyval/src/field_element/soft.rs
+++ b/polyval/src/field_element/soft.rs
@@ -37,6 +37,15 @@ use core::{
 use soft_impl::{karatsuba, mont_reduce};
 use universal_hash::array::{Array, ArraySize};
 
+/// Stub implementation which only makes `PolyvalGeneric::h` work.
+// TODO(tarcieri): actually implement this optimization?
+#[inline]
+pub(super) fn powers_of_h<const N: usize>(h: FieldElement) -> [FieldElement; N] {
+    let mut ret = [FieldElement::default(); N];
+    ret[N - 1] = h;
+    ret
+}
+
 /// Perform carryless multiplication of `y` by `h` and return the result.
 #[inline]
 pub(super) fn polymul(y: FieldElement, h: FieldElement) -> FieldElement {
@@ -46,6 +55,7 @@ pub(super) fn polymul(y: FieldElement, h: FieldElement) -> FieldElement {
 
 /// Process an individual block.
 // TODO(tarcieri): implement `proc_par_blocks` for soft backend?
+#[inline]
 pub(super) fn proc_block(h: FieldElement, y: FieldElement, x: &Block) -> FieldElement {
     let x = FieldElement::from(x);
     polymul(y + x, h)
@@ -53,6 +63,7 @@ pub(super) fn proc_block(h: FieldElement, y: FieldElement, x: &Block) -> FieldEl
 
 /// Process multiple blocks.
 // TODO(tarcieri): optimized implementation?
+#[inline]
 pub(super) fn proc_par_blocks<const N: usize, U: ArraySize>(
     powers_of_h: &[FieldElement; N],
     mut y: FieldElement,

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::mulx::mulx;
 pub use universal_hash;
 
 use core::fmt::{self, Debug};
-use field_element::{FieldElement, InitToken, detect_intrinsics};
+use field_element::{FieldElement, InitToken, has_intrinsics};
 use universal_hash::{
     KeyInit, ParBlocks, Reset, UhfBackend, UhfClosure, UniversalHash,
     array::{Array, ArraySize},
@@ -76,11 +76,11 @@ impl<const N: usize> PolyvalGeneric<N> {
     /// Initialize POLYVAL with the given `H` field element and initial block.
     #[must_use]
     pub fn new_with_init_block(h: &Key, init_block: u128) -> Self {
-        let (token, _has_intrinsics) = detect_intrinsics();
+        let has_intrinsics = has_intrinsics().0;
         Self {
-            powers_of_h: FieldElement::from(h).powers_of_h(),
+            powers_of_h: FieldElement::from(h).powers_of_h(has_intrinsics),
             y: init_block.into(),
-            has_intrinsics: token,
+            has_intrinsics,
         }
     }
 


### PR DESCRIPTION
The only time we actually use powers-of-`H` is when we have intrinsics anyway, so we might as well make use of the intrinsics when computing them.

This factors the computation into the `autodetect` module with autodetection support and a fallback to a stub implementation for the `soft` backend which only initializes and access the last element (which is layout-compatible with the intrinsics implementation, if we ever decide to add the requisite support to the soft backend)