### PR TITLE
polyval: expose `FieldElement` under `hazmat` feature

### DIFF
--- a/.github/workflows/polyval.yml
+++ b/.github/workflows/polyval.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   # Ensure crate builds on a `no_std` target
-  build-no_std:
+  build-no-std:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,7 +30,7 @@ jobs:
         with:
           toolchain: stable
           targets: thumbv7em-none-eabi
-      - run: cargo check --target thumbv7em-none-eabi --release --features zeroize
+      - run: cargo check --target thumbv7em-none-eabi --release --all-features
 
   # Tests with CPU feature detection enabled
   test-autodetect:

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -15,12 +15,15 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 edition = "2024"
 
+[features]
+hazmat = []
+
 [dependencies]
 cpubits = "0.1.0-rc.1"
 universal-hash = { version = "0.6.0-rc.8", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
-[target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+[target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]

--- a/polyval/src/hazmat.rs
+++ b/polyval/src/hazmat.rs
@@ -1,0 +1,8 @@
+//! Hazardous materials: functionality which can be misused and needs to be used with care.
+//!
+//! <div class="warning">
+//! Functionality provided in this module is low-level and intended for constructing higher-level
+//! primitives as opposed to being used directly.
+//! </div>
+
+pub use crate::field_element::FieldElement;

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -6,6 +6,9 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 
+#[cfg(feature = "hazmat")]
+pub mod hazmat;
+
 mod field_element;
 mod mulx;
 


### PR DESCRIPTION
Adds a new `hazmat` feature and conditionally adds a `pub` re-export of the `FieldElement` type under a new `hazmat` module.

All of its inherent methods are still private, so this just exposes the trait impls backed by the `soft` implementation.

We will probably need to expose some things like `InitToken` and functions like `polymul` that accept it and select between intrinsics/soft implementations to enable performance-oriented usage of this type, which is why it's being placed in a `hazmat` module where we can potentially put some of the other things that would actually make it useful.