### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "hex-literal",
  "polyval",
@@ -146,7 +146,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.3"
+version = "0.9.0-rc.4"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.5"
+version = "0.7.0-rc.6"
 dependencies = [
  "cpubits",
  "cpufeatures",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -16,7 +16,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-polyval = { version = "0.7.0-rc.3", path = "../polyval" }
+polyval = { version = "0.7.0-rc.6", path = "../polyval" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.9.0-rc.3"
+version = "0.9.0-rc.4"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.7.0-rc.5"
+version = "0.7.0-rc.6"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
Releases the following (which all now use `universal_hash::common`):

- `ghash` v0.6.0-rc.4
- `poly1305` v0.9.0-rc.4
- `polyval` v0.7.0-rc.6