### PR TITLE
polyval: bump `cpubits` to v0.1.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251aaca52dbc19119279d9364222e188ffdf48006791040bfd002617ab0ebc41"
+checksum = "4ee6439310d1504c84ab741743fc93ea845bb9f6ab8b44962237957810246118"
 
 [[package]]
 name = "cpufeatures"

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 hazmat = []
 
 [dependencies]
-cpubits = "0.1.0-rc.1"
+cpubits = "0.1.0-rc.2"
 universal-hash = { version = "0.6.0-rc.8", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -43,7 +43,10 @@ unused_qualifications = "warn"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(polyval_backend, values("soft"))']
+check-cfg = [
+    'cfg(cpubits, values("16", "32", "64"))',
+    'cfg(polyval_backend, values("soft"))'
+]
 
 [lints.clippy]
 borrow_as_ptr = "warn"


### PR DESCRIPTION
This adds `cfg(cpubits = "...")` support