### PR TITLE
Bump `universal-hash` dependency to v0.6.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "hex-literal",
  "polyval",
@@ -146,7 +146,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.4"
+version = "0.9.0-rc.5"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.6"
+version = "0.7.0-rc.7"
 dependencies = [
  "cpubits",
  "cpufeatures",
@@ -343,9 +343,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82084f2919885ea910502c74f0a362827aaad3d28d142ca97448bfb39c7e271a"
+checksum = "058482a494bb3c9c39447d8b40a3a0f38ebb3dccaf02c5a2d681e69035f8da11"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -16,7 +16,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-polyval = { version = "0.7.0-rc.6", path = "../polyval" }
+polyval = { version = "0.7.0-rc.7", path = "../polyval" }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.9.0-rc.4"
+version = "0.9.0-rc.5"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"
@@ -13,7 +13,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-universal-hash = { version = "0.6.0-rc.8", default-features = false }
+universal-hash = { version = "0.6.0-rc.10", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.7.0-rc.6"
+version = "0.7.0-rc.7"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -20,7 +20,7 @@ hazmat = []
 
 [dependencies]
 cpubits = "0.1.0-rc.2"
-universal-hash = { version = "0.6.0-rc.8", default-features = false }
+universal-hash = { version = "0.6.0-rc.10", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]


### PR DESCRIPTION
Also cuts the following releases:
- `ghash` v0.6.0-rc.5
- `poly1305` v0.9.0-rc.5
- `polyval` v0.7.0-rc.7