### PR TITLE
ghash: base degree of parallelism on `polyval`

### DIFF
--- a/ghash/src/lib.rs
+++ b/ghash/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub use polyval::universal_hash;
 
-use polyval::PolyvalGeneric;
+use polyval::{DEFAULT_PARALLELISM, PolyvalGeneric};
 use universal_hash::{
     KeyInit, UhfBackend, UhfClosure, UniversalHash,
     array::ArraySize,
@@ -31,23 +31,19 @@ pub type Tag = universal_hash::Block<GHash>;
 
 /// **GHASH**: universal hash over GF(2^128) used by AES-GCM.
 ///
-/// GHASH is a universal hash function used for message authentication in
-/// the AES-GCM authenticated encryption cipher.
-pub type GHash = GHashGeneric<8>;
+/// GHASH is a universal hash function used for message authentication in the AES-GCM authenticated
+/// encryption cipher.
+pub type GHash = GHashGeneric<{ DEFAULT_PARALLELISM }>;
 
 /// **GHASH**: universal hash over GF(2^128) used by AES-GCM.
 ///
-/// GHASH is a universal hash function used for message authentication in
-/// the AES-GCM authenticated encryption cipher.
+/// GHASH is a universal hash function used for message authentication in the AES-GCM authenticated
+/// encryption cipher.
 ///
-/// Paramaterized on a constant that determines how many
-/// blocks to process at once: higher numbers use more memory,
-/// and require more time to re-key, but process data significantly
-/// faster.
-///
-/// (This constant is not used when acceleration is not enabled.)
+/// Parameterized on a constant that determines how many blocks to process at once: higher numbers
+/// use more memory, and require more time to re-key, but process data significantly faster.
 #[derive(Clone)]
-pub struct GHashGeneric<const N: usize = 8>(PolyvalGeneric<N>);
+pub struct GHashGeneric<const N: usize = { DEFAULT_PARALLELISM }>(PolyvalGeneric<N>);
 
 impl<const N: usize> KeySizeUser for GHashGeneric<N> {
     type KeySize = U16;

--- a/polyval/src/lib.rs
+++ b/polyval/src/lib.rs
@@ -34,6 +34,9 @@ pub const BLOCK_SIZE: usize = 16;
 /// Size of a POLYVAL key in bytes
 pub const KEY_SIZE: usize = 16;
 
+/// Default degree of parallelism to use.
+pub const DEFAULT_PARALLELISM: usize = FieldElement::DEFAULT_PARALLELISM;
+
 /// POLYVAL keys (16-bytes)
 pub type Key = Array<u8, U16>;
 
@@ -47,7 +50,7 @@ pub type Tag = Array<u8, U16>;
 ///
 /// This type alias uses the default amount of parallelism for the target (`8` for `aarch64`/`x86`,
 /// `1` for other targets using a pure Rust fallback implementation).
-pub type Polyval = PolyvalGeneric<{ FieldElement::DEFAULT_PARALLELISM }>;
+pub type Polyval = PolyvalGeneric<{ DEFAULT_PARALLELISM }>;
 
 /// **POLYVAL**: GHASH-like universal hash over GF(2^128).
 ///
@@ -56,7 +59,7 @@ pub type Polyval = PolyvalGeneric<{ FieldElement::DEFAULT_PARALLELISM }>;
 ///
 /// (This constant is not used when acceleration is not enabled.)
 #[derive(Clone)]
-pub struct PolyvalGeneric<const N: usize = { FieldElement::DEFAULT_PARALLELISM }> {
+pub struct PolyvalGeneric<const N: usize = { DEFAULT_PARALLELISM }> {
     /// Powers of H in descending order.
     ///
     /// (H^N, H^(N-1)...H)


### PR DESCRIPTION
We currently choose a value of 1 for the software backend, or 8 if we're using intrinsics, where the latter can best exploit the powers-of-H optimization (or going forward, the R/F algorithm in #290).

The "parallelism" here represents the number of blocks we process in a single logical operation from the API perspective. The actual processing is also parallel in that it uses ILP, but blocks are still ultimately processed in sequence. However, the aforementioned optimizations eliminate some of the computations we'd otherwise perform processing input a block-at-a-time, like deferring or even completely eliminating Montgomery reductions.

All that said, `ghash` was unconditionally always using 8-block inputs, even if the software backend was in use. The software backend now implements powers-of-H for consistency, but it seems unlikely to provide much benefit, especially compared to the benefit for when intrinsics are available, and that still holds for the R/F algorithm as explicitly stated in the paper.

This re-exports a `polyval::DEFAULT_PARALLELISM` constant which is conditionally set to 1 or 8 depending on if the `soft` backend is in use, and has `ghash` use that to decide its degree of parallelism (which, ultimately, is selecting the degree of parallelism to use in the `polyval` core it's built on)