### PR TITLE
polyval: bump `cpubits` to v0.1

### DIFF
--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 hazmat = []
 
 [dependencies]
-cpubits = "0.1.0-rc.2"
+cpubits = "0.1"
 universal-hash = { version = "0.6.0-rc.10", default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 


### PR DESCRIPTION
Release PR: RustCrypto/utils#1444