### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "hex-literal",
  "polyval",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.5"
+version = "0.9.0-rc.6"
 dependencies = [
  "cpufeatures",
  "hex-literal",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.7"
+version = "0.7.0-rc.8"
 dependencies = [
  "cpubits",
  "cpufeatures",

--- a/ghash/Cargo.toml
+++ b/ghash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghash"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -16,7 +16,7 @@ rust-version = "1.85"
 edition = "2024"
 
 [dependencies]
-polyval = { version = "0.7.0-rc.7", features = ["hazmat"] }
+polyval = { version = "0.7.0-rc.8", features = ["hazmat"] }
 
 # optional dependencies
 zeroize = { version = "1", optional = true, default-features = false }

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.9.0-rc.5"
+version = "0.9.0-rc.6"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "The Poly1305 universal hash function and message authentication code"

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.7.0-rc.7"
+version = "0.7.0-rc.8"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -83,7 +83,7 @@ trivially_copy_pass_by_ref = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"
 suspicious_arithmetic_impl = "allow" # POLYVAL arithmetic ops are atypical
-#undocumented_unsafe_blocks = "warn" TODO
+undocumented_unsafe_blocks = "warn"
 unnecessary_safety_comment = "warn"
 unwrap_in_result = "warn"
 unwrap_used = "warn"

--- a/polyval/src/backend/intrinsics.rs
+++ b/polyval/src/backend/intrinsics.rs
@@ -53,6 +53,7 @@ impl State {
 
     pub(crate) fn proc_block(&mut self, block: &Block) {
         self.acc = if self.has_intrinsics() {
+            // SAFETY: we have just used CPU feature detection to ensure intrinsics are available
             unsafe { intrinsics_impl::proc_block(&self.expanded_key, self.acc, block) }
         } else {
             (self.acc + block.into()) * self.expanded_key.h1
@@ -61,6 +62,7 @@ impl State {
 
     pub(crate) fn proc_par_blocks(&mut self, par_blocks: &ParBlocks) {
         if self.has_intrinsics() {
+            // SAFETY: we have just used CPU feature detection to ensure intrinsics are available
             self.acc = unsafe {
                 intrinsics_impl::proc_par_blocks(&self.expanded_key, self.acc, par_blocks)
             };


### PR DESCRIPTION
Releases the following:
- `ghash` v0.6.0-rc.6
- `poly1305` v0.9.0-rc.6
- `polyval` v0.7.0-rc.8