### PR TITLE
poly1305 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.6"
+version = "0.9.0"
 dependencies = [
  "cpufeatures",
  "hex-literal",

--- a/poly1305/CHANGELOG.md
+++ b/poly1305/CHANGELOG.md
@@ -5,14 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.0 (UNRELEASED)
+## 0.9.0 (2026-05-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#228])
 - Relax MSRV policy and allow MSRV bumps in patch releases
-- Update to `universal-hash` v0.6 ([#213])
+- Update to `universal-hash` v0.6 ([#213], [#310])
+- Bump `cpufeatures` to v0.3 ([#292])
+- Rename `poly1305_force_soft` => `poly1305_backend="soft"` ([#323])
+
+### Removed
+- `opaque-debug` dependencies ([#233])
 
 [#213]: https://github.com/RustCrypto/universal-hashes/pull/213
 [#228]: https://github.com/RustCrypto/universal-hashes/pull/228
+[#233]: https://github.com/RustCrypto/universal-hashes/pull/233
+[#292]: https://github.com/RustCrypto/universal-hashes/pull/292
+[#310]: https://github.com/RustCrypto/universal-hashes/pull/310
+[#323]: https://github.com/RustCrypto/universal-hashes/pull/323
 
 ## 0.8.0 (2022-07-31)
 ### Changed

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.9.0-rc.6"
+version = "0.9.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/poly1305/LICENSE-MIT
+++ b/poly1305/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2025 The RustCrypto Project Developers
+Copyright (c) 2015-2026 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
## Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#228])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `universal-hash` v0.6 ([#213], [#310])
- Bump `cpufeatures` to v0.3 ([#292])
- Rename `poly1305_force_soft` => `poly1305_backend="soft"` ([#323])

## Removed
- `opaque-debug` dependencies ([#233])

[#213]: https://github.com/RustCrypto/universal-hashes/pull/213
[#228]: https://github.com/RustCrypto/universal-hashes/pull/228
[#233]: https://github.com/RustCrypto/universal-hashes/pull/233
[#292]: https://github.com/RustCrypto/universal-hashes/pull/292
[#310]: https://github.com/RustCrypto/universal-hashes/pull/310
[#323]: https://github.com/RustCrypto/universal-hashes/pull/323