### PR TITLE
polyval: restore `Zeroize` impl on `FieldElement`

### DIFF
--- a/polyval/src/field_element.rs
+++ b/polyval/src/field_element.rs
@@ -39,6 +39,9 @@ use core::{
     ops::{Add, BitAnd, BitOr, BitXor, Mul, MulAssign, Shl},
 };
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 /// An element in POLYVAL's field.
 ///
 /// This type represents an element of the binary field GF(2^128) modulo the irreducible polynomial
@@ -159,6 +162,13 @@ impl MulAssign for FieldElement {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for FieldElement {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
This was removed in #343 but is part of the public API, which lead to downstream breakages:

https://github.com/RustCrypto/AEADs/actions/runs/29241312311/job/86787771717?pr=858#step:4:84