### PR TITLE
polyval v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cpubits",
  "cpufeatures",

--- a/polyval/CHANGELOG.md
+++ b/polyval/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2026-07-16)
+### Fixed
+- Restore accidentally removed `Zeroize` impl on `FieldElement` ([#350])
+
+[#350]: https://github.com/RustCrypto/universal-hashes/pull/350
+
 ## 0.7.2 (2026-07-11)
+### Changed
+- Tweak zeroization ([#343])
+
 ### Fixed
 - Actually detect `avx`+`pclmulqdq` as [#317] actually was detecting 256-bit PCLMULQDQ ([#347])
 
+[#343]: https://github.com/RustCrypto/universal-hashes/pull/343
 [#347]: https://github.com/RustCrypto/universal-hashes/pull/347
 
 ## 0.7.1 (2026-02-28)

--- a/polyval/Cargo.toml
+++ b/polyval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyval"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Fixed
- Restore accidentally removed `Zeroize` impl on `FieldElement` ([#350])

[#350]: https://github.com/RustCrypto/universal-hashes/pull/350
